### PR TITLE
Add support for XL ships, such as those added by VRO

### DIFF
--- a/md/warehousefleets.xml
+++ b/md/warehousefleets.xml
@@ -251,7 +251,7 @@
             <param name="ship" value="$ship" />
           </run_actions>
         </do_if>
-        <do_if value="$ship.isclass.ship_m or $ship.isclass.ship_l">
+        <do_if value="$ship.isclass.ship_m or $ship.isclass.ship_l or $ship.isclass.ship_xl">
           <run_actions ref="AddStations">
             <param name="stations" value="$targetStations" />
             <param name="newTargets" value="$order.$targets" />
@@ -265,7 +265,7 @@
             <param name="ship" value="$ship" />
           </run_actions>
         </do_if>
-        <do_elseif value="$ship.isclass.ship_l">
+        <do_elseif value="$ship.isclass.ship_l or $ship.isclass.ship_xl">
           <run_actions ref="AddStations">
             <param name="stations" value="$targetStations" />
             <param name="newTargets" value="$order.$targetsL" />


### PR DESCRIPTION
No special support, it just considers them in the same way as L ships. Could add yet another category of target for XL, but as they have the same dock requirements its not obviously necessary. 
Actually it lets you use the XL supply ships also, which are vanilla and have very large storage.