### PR TITLE
Fix - various fixes

### DIFF
--- a/aiscripts/order.returntowarehouse.xml
+++ b/aiscripts/order.returntowarehouse.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<aiscript name="ReturnToWarehouse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/manuel/Nextcloud/X4 Foundations/2026-02-28/libraries/aiscripts.xsd" version="6">
+<aiscript name="ReturnToWarehouse" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/manuel/Nextcloud/X4 Foundations/2026-02-28/libraries/aiscripts.xsd" version="7">
 
   <order id="ReturnToWarehouse" name="Return to Warehouse" description="Return to Warehouse" category="internal">
     <params>
       <param name="destination" default="null" advanced="true" type="internal" text="Home Station" />
+      <param name="debugchance" default="0" type="internal" text="Debug chance">
+        <patch sinceversion="7" value="0" />
+      </param>
     </params>
     <requires>
       <match shiptype="shiptype.lasertower" negate="true" />
@@ -33,6 +36,7 @@
         <run_script name="'move.generic'">
           <param name="destination" value="$destination" />
           <param name="endintargetzone" value="true" />
+          <param name="debugchance" value="$debugchance" />
         </run_script>
       </do_if>
       <label name="finish" />

--- a/aiscripts/order.warehousefleet.xml
+++ b/aiscripts/order.warehousefleet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<aiscript name="WarehouseFleet" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/manuel/Nextcloud/X4 Foundations/2026-02-28/libraries/aiscripts.xsd" version="43">
+<aiscript name="WarehouseFleet" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/manuel/Nextcloud/X4 Foundations/2026-02-28/libraries/aiscripts.xsd" version="44">
 
   <order id="WarehouseFleet" name="WarehouseFleet" description="Warehouse Fleet" category="trade" infinite="true">
     <params>
@@ -61,6 +61,10 @@
       </param>
       <param name="waitInDockL" type="bool" default="global.$WarehouseFleets.$waitInDockL" text="Dock idle L-sized ships">
         <patch sinceversion="43" value="global.$WarehouseFleets.$waitInDockL" />
+      </param>
+      <param name="debugchance" type="bool" default="0" advanced="true" text="Debug">
+        <input_param name="truevalue" value="100" />
+        <patch sinceversion="44" value="0" />
       </param>
     </params>
 

--- a/aiscripts/order.warehousefleet.xml
+++ b/aiscripts/order.warehousefleet.xml
@@ -62,8 +62,7 @@
       <param name="waitInDockL" type="bool" default="global.$WarehouseFleets.$waitInDockL" text="Dock idle L-sized ships">
         <patch sinceversion="43" value="global.$WarehouseFleets.$waitInDockL" />
       </param>
-      <param name="debugchance" type="bool" default="0" advanced="true" text="Debug">
-        <input_param name="truevalue" value="100" />
+      <param name="debugchance" default="0" type="internal" text="Debug">
         <patch sinceversion="44" value="0" />
       </param>
     </params>

--- a/libraries/icons.xml
+++ b/libraries/icons.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <diff xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/manuel/Nextcloud/X4 Foundations/2026-02-28/libraries/diff.xsd">
   <add sel="/icons">
-    <icon name="order_warehousefleet" texture="assets\fx\gui\textures\order\order_traderoutine.tga" height="32" width="32"></icon>
+    <icon name="order_warehousefleet" texture="assets\textures\ui\order\order_traderoutine.tga" height="32" width="32"></icon>
   </add>
   <add sel="/icons">
-    <icon name="order_returntowarehouse" texture="assets\fx\gui\textures\order\order_movetoobject.tga" height="32" width="32"></icon>
+    <icon name="order_returntowarehouse" texture="assets\textures\ui\order\order_movetoobject.tga" height="32" width="32"></icon>
   </add>
 </diff>

--- a/md/warehousefleets.xml
+++ b/md/warehousefleets.xml
@@ -159,10 +159,7 @@
                     <check_value value="not $ship.exists" />
                   </conditions>
                   <actions>
-                    <!-- @$ship.idcode: the ship component is already invalid here (that's the cue
-                         condition), so the property lookup must be guarded. Without the @ prefix
-                         this raises a Property-lookup-failed error every time a tracked ship dies. -->
-                    <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'" text="'Ship ' + @$ship.idcode + ' destroyed, cancelling cues'" output="false" append="true" />
+                    <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'" text="'Ship was destroyed, cancelling cues'" output="false" append="true" />
                     <cancel_cue cue="ShipSpecificCues" />
                   </actions>
                 </cue>

--- a/md/warehousefleets.xml
+++ b/md/warehousefleets.xml
@@ -724,7 +724,7 @@
                 $backpressure = $backpressure,
                 $provider = $provider,
                 $receiver = $receiver,
-                $providerID = $receiver.idcode,
+                $providerID = $provider.idcode,
                 $receiverID = $receiver.idcode,
                 $providerOffer = $providerOffer, 
                 $receiverOffer = $receiverOffer,

--- a/md/warehousefleets.xml
+++ b/md/warehousefleets.xml
@@ -831,7 +831,7 @@
             <set_value name="$money" exact="$amount * $ware.averageprice" />
             <remove_cargo object="$ship" ware="$ware" exact="$amount" />
             <transfer_money from="faction.ownerless" to="$recipient" amount="$money" />
-            <set_value name="$recoveryText" exact="'Refunding '+$amount+' '+$ware+'at the average price of '+$ware.averageprice/100.0+'Cr'" />
+            <set_value name="$recoveryText" exact="'Refunding '+$amount+' '+$ware+' at the average price of '+$ware.averageprice/100.0+'Cr'" />
             <write_to_logbook category="upkeep" entity="$warehouse" object="$ship" interaction="showonmap" title="'WarehouseFleet: Cargo Empty Routine ('+$warehouse.idcode+')'" money="$money" text="$recoveryText" />
           </do_all>
         </do_if>

--- a/md/warehousefleets.xml
+++ b/md/warehousefleets.xml
@@ -159,7 +159,10 @@
                     <check_value value="not $ship.exists" />
                   </conditions>
                   <actions>
-                    <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'" text="'Ship ' + $ship.idcode + ' destroyed, cancelling cues'" output="false" append="true" />
+                    <!-- @$ship.idcode: the ship component is already invalid here (that's the cue
+                         condition), so the property lookup must be guarded. Without the @ prefix
+                         this raises a Property-lookup-failed error every time a tracked ship dies. -->
+                    <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'" text="'Ship ' + @$ship.idcode + ' destroyed, cancelling cues'" output="false" append="true" />
                     <cancel_cue cue="ShipSpecificCues" />
                   </actions>
                 </cue>
@@ -187,7 +190,11 @@
 
                 <cue name="ReorderTargetsOnSave" instantiate="true">
                   <conditions>
-                    <event_object_order_ready object="$ship" />
+                    <!-- check="false" tells the engine not to raise an error if $ship is gone by
+                         the time the event is evaluated (e.g. ship destroyed). Without it, this
+                         cue throws "Component 0x0 does not exist any more" on ship death. -->
+                    <event_object_order_ready object="$ship" check="false" />
+                    <check_value value="@$ship.exists" />
                     <check_value value="@event.param.id == 'WarehouseFleet'" />
                   </conditions>
                   <actions>

--- a/md/warehousefleets.xml
+++ b/md/warehousefleets.xml
@@ -802,7 +802,7 @@
             <return value="table[
               $provider = $referenceTransport.$provider,
               $receiver = $referenceTransport.$receiver,
-              $providerID = $referenceTransport.$receiver.idcode,
+              $providerID = $referenceTransport.$provider.idcode,
               $receiverID = $referenceTransport.$receiver.idcode,
               $wares = $transportWares,
               $cargoUsage = $cargoUsage,


### PR DESCRIPTION
# PR: Bugfixes
## untraceable $debugchance interrupt error, wrong reservation keys, ship-death errors, broken order icons

Four independent, low-risk fixes. Each reproduces on a clean 1.12 install; none changes intended behavior.

### 1. "Property lookup failed: $debugchance" from interrupt handlers (the untraceable one)

**Symptom** (common debug log, intermittent, very hard to trace):

```
Error: Error in AI script WarehouseFleet on entity 0x...: Property lookup failed: $debugchance
* Expression: $debugchance
* Action: <debug_text>, line 13
```

There is no `<debug_text>` anywhere in `order.warehousefleet.xml`, which makes this look impossible. The explanation: vanilla interrupt handler actions execute **in the interrupted script's variable scope**, but the error is attributed to the interrupted script while the line number belongs to the **handler's own file**. Line 13 here is vanilla `aiscripts/interrupt.inspected.xml`:

```xml
<debug_text text="'%s %s accosted by %s %s %s %s in sector %s.'..." chance="$debugchance"/>
```

`WarehouseFleet` registers `<handler ref="InspectedHandler"/>` (and others that read `$debugchance` the same way) but never declares `$debugchance` — every vanilla order does, which is why vanilla never hits this. So every police/pirate inspection of a WarehouseFleet ship throws. `ReturnToWarehouse` has the same handler set and the same gap.

**Fix**: declare a `debugchance` param in both orders (default 0; on `WarehouseFleet` it doubles as an advanced "Debug" toggle with `truevalue=100`, mirroring vanilla orders). The `<patch sinceversion>` on the param is essential: params only initialize at order creation, so without it every already-running order instance in existing saves keeps erroring until the player manually re-issues the behaviour. `ReturnToWarehouse` additionally passes it down to `move.generic` like vanilla callers do.

### 2. Copy-paste bug: `$providerID = $receiver.idcode`

In `FindPossibleTransports` (possible-transport table) and in `AssembleTrip`'s result table, `$providerID` is set to the **receiver's** idcode. These IDs feed the delivery bookkeeping that `FindPossibleTransports` itself uses to compute reservations (`'$' + $delivery.$providerID + '/' + wareID`) and the backpressure calculation (which matches on `$providerID`/`$receiverID` of past deliveries):

- outbound (provider-side) reservations are subtracted from the wrong key — the receiver's — so a provider's stock is double-counted while other ships plan against it, and the receiver's key accumulates a bogus negative offset;
- backpressure (the anti-ping-pong damping) can never match, because no delivery ever records the true provider id.

**Fix**: `$providerID = $provider.idcode` in both places. Self-healing on existing saves: wrong delivery records age out via the GarbageCollector within 30 minutes.

### 3. Errors when a tracked ship dies

Two per-ship cues raise errors at exactly the moment they exist to handle — ship death:

- `ShipDeleteWatcher` logs `$ship.idcode` when its condition is "the ship no longer exists" → guaranteed *Property lookup failed* on every tracked-ship death. Fix: `@$ship.idcode`.
- `ReorderTargetsOnSave` listens with `event_object_order_ready object="$ship"` without `check="false"` → *"Component 0x0 does not exist any more"* when the ship is gone. Fix: `check="false"` plus an explicit `@$ship.exists` condition.

### 4. Order icons don't resolve on X4 9.00

`libraries/icons.xml` points at `assets\fx\gui\textures\order\...` — the pre-9.0 texture path. In 9.00 the vanilla icon library uses `assets\textures\ui\order\...` for these textures, so both mod order icons are broken. Fix: update the two paths. (Also fixed in passing: a missing space in the refund logbook text — "Refunding 100 Oreat the average price".)

## Files changed

| File | Change |
| --- | --- |
| `aiscripts/order.warehousefleet.xml` | v43→44: `debugchance` param + `sinceversion="44"` patch (fix 1) |
| `aiscripts/order.returntowarehouse.xml` | v6→7: `debugchance` param + `sinceversion="7"` patch, passed to `move.generic` (fix 1) |
| `md/warehousefleets.xml` | `$providerID` in two tables (fix 2); `@$ship.idcode` guard, `check="false"` + exists guard (fix 3); refund-text space |
| `libraries/icons.xml` | two texture paths updated to the 9.00 location (fix 4) |

## Save compatibility

No blocking actions are added or moved in either aiscript (params are metadata), so suspended script states import cleanly. The param `sinceversion` patches heal all running order instances on load — that is the entire point of fix 1. No global/cue state changes.
