### PR TITLE
Feature - add mining fallback for idling warehouse fleet miner ships

### DIFF
--- a/aiscripts/order.warehousefleet.mining.xml
+++ b/aiscripts/order.warehousefleet.mining.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="utf-8"?>
+<aiscript name="order.warehousefleet.mining" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="aiscripts.xsd" version="1">
+
+  <!--
+    One-shot mining order issued by the WarehouseFleet idle-mining fallback.
+
+    Why this exists: vanilla MiningRoutine is an infinite loop (mine -> sell -> mine -> ...).
+    Even with maxsell=0 and a duration cap, the inner AutoMine sub-order keeps the ship cycling,
+    which conflicts with the WarehouseFleet delivery flow (supply-target first, then home
+    warehouse, then the configured cargo emptying routine).
+
+    What this does: find a resource area for the chosen ware near the anchor sector, reserve it,
+    dispatch a single MiningCollect sub-order (the same leaf order vanilla mining uses), wait
+    for it to end (cargo full or area depleted), release the reservation, and END. No selling,
+    no looping. The ship then returns to its default behaviour (WarehouseFleet), whose scheduler
+    picks up the cargo on the next cycle and routes it through DeliverMinedCargoOrFallback.
+  -->
+
+  <order id="WarehouseFleetMine" name="WarehouseFleet Mining" description="One-shot mining for the WarehouseFleet idle-mining fallback." category="internal" allowinloop="false">
+    <params>
+      <param name="ware" required="true" type="ware" text="Ware to mine" comment="The single ware to gather. Picked by PickMiningWare in the MD scheduler.">
+        <input_param name="cancarry" value="this.ship"/>
+        <input_param name="isminable" value="true"/>
+      </param>
+      <param name="anchorSector" required="true" type="sector" text="Anchor sector" comment="Sector to search for resource areas in. Normally the home warehouse's sector."/>
+      <param name="maxGateDistance" default="0" type="number" text="Max gate distance" comment="How many gate hops away from anchorSector we may search if the anchor sector has no resource area for the chosen ware. 0 = anchor sector only.">
+        <input_param name="min" value="0"/>
+        <input_param name="max" value="10"/>
+        <input_param name="step" value="1"/>
+      </param>
+      <!-- $debugchance must exist in this script's scope: the vanilla interrupt handlers below
+           (e.g. interrupt.inspected) execute their actions in the interrupted script's variable
+           scope and read $debugchance unguarded. Without this param, every inspection event on a
+           ship running this order raises "Property lookup failed: $debugchance". -->
+      <param name="debugchance" type="bool" default="0" advanced="true" text="Debug">
+        <input_param name="truevalue" value="100"/>
+      </param>
+    </params>
+    <requires primarypurpose="purpose.mine"/>
+    <!-- condition="false" suppresses the map marker entirely. Without this, even an internal-
+         category order can leave a placeholder "?" icon hovering on the sector since X4 still
+         resolves the <location object="..."> for display. Same idiom as vanilla SalvageDeliver. -->
+    <location condition="false" object="$anchorSector"/>
+  </order>
+
+  <interrupts>
+    <handler ref="SectorChangeHandler"/>
+    <handler ref="AttackHandler"/>
+    <handler ref="MissileLockHandler"/>
+    <handler ref="ScannedHandler"/>
+    <handler ref="InspectedHandler"/>
+    <handler ref="FoundAbandonedHandler"/>
+    <handler ref="FoundLockboxHandler"/>
+    <handler ref="ResupplyHandler"/>
+    <handler ref="TargetInvalidHandler"/>
+    <handler ref="TideHandler"/>
+  </interrupts>
+
+  <init>
+    <set_value name="$resourcearea" exact="null"/>
+    <set_command command="command.mining" param="$anchorSector"/>
+  </init>
+
+  <attention min="unknown">
+    <actions>
+      <label name="start"/>
+
+      <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+        text="'[' + player.age + '] WarehouseFleetMine: start - ware=' + $ware + ' anchor=' + @$anchorSector.knownname + ' maxGateDistance=' + $maxGateDistance + ' shipCargoFor=' + this.ship.cargo.{$ware}.max" append="true"/>
+
+      <!-- Bail out cleanly if our inputs are gone. -->
+      <do_if value="not @$anchorSector.exists or not @$ware">
+        <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+          text="'  WarehouseFleetMine: anchor sector or ware invalid; aborting'" append="true"/>
+        <return/>
+      </do_if>
+
+      <!-- The ship must actually be able to carry this ware. -->
+      <do_if value="not this.ship.cargo.{$ware}.max">
+        <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+          text="'  WarehouseFleetMine: ship cannot carry ' + $ware + '; aborting'" append="true"/>
+        <return/>
+      </do_if>
+
+      <!-- Ship already effectively loaded with this ware? Don't fly to a resource area just to
+           top off the last sliver of cargo and immediately bail. Threshold: less than 2% free.
+           Integer-safe form: free*50 < max  <=>  free < max*0.02. -->
+      <do_if value="(this.ship.cargo.{$ware}.free * 50) lt this.ship.cargo.{$ware}.max">
+        <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+          text="'  WarehouseFleetMine: ship effectively full of ' + $ware + ' (' + this.ship.cargo.{$ware}.count + '/' + this.ship.cargo.{$ware}.max + ', free=' + this.ship.cargo.{$ware}.free + ' &lt; 2%); skip mining, let scheduler deliver'" append="true"/>
+        <return/>
+      </do_if>
+
+      <!-- Tunables for the sector-and-patch picker.
+           - DistanceFactor: in score = yieldrating / (1 + gateDist * factor). Vanilla uses 0.2;
+             0.4 makes the ship prefer staying close unless a neighbor is substantially richer.
+           - FloorRatio Min/Max: random fraction of the chosen sector's headline yieldrating used
+             as the minrating floor for find_resource. Spreads ships across patches instead of
+             all converging on the single best rock.
+           - SectorRetries: how many top-scored sectors to attempt before giving up and doing the
+             unlucky-fallback (no-minrating call). Includes the best one. -->
+      <set_value name="$miningDistanceFactor" exact="0.4f"/>
+      <set_value name="$miningFloorRatioMin" exact="0.3f"/>
+      <set_value name="$miningFloorRatioMax" exact="0.95f"/>
+      <set_value name="$miningFloorRelaxDiv" exact="0.75f"/>
+      <set_value name="$miningSectorRetries" exact="4"/>
+
+      <!-- Build {sector -> gate distance} table, respecting sector activity/travel blacklists. -->
+      <include_interrupt_actions ref="GetBlacklistgroup"/>
+      <run_script name="'lib.find.sectors.inrange'" result="$gdTable">
+        <param name="refobject" value="$anchorSector"/>
+        <param name="mingatedistance" value="0"/>
+        <param name="maxgatedistance" value="$maxGateDistance"/>
+        <param name="blacklistgroup" value="$blacklistgroup"/>
+        <param name="returndistancetable" value="true"/>
+        <param name="debugchance" value="$debugchance"/>
+      </run_script>
+
+      <!-- Score each candidate. Skip sectors that don't exist or report zero yield (covers
+           undiscovered sectors and sectors with no resources of this ware). Score is stored
+           NEGATED so a plain ascending sort_list gives us highest-first. -->
+      <set_value name="$scoreTable" exact="table[]"/>
+      <do_for_each in="$gdTable.keys.list" name="$secCand">
+        <do_if value="not @$secCand.exists">
+          <continue/>
+        </do_if>
+        <do_if value="$secCand.isblacklisted.{blacklisttype.sectoractivity}.{$blacklistgroup}.{this.assignedcontrolled} or $secCand.isblacklisted.{blacklisttype.sectortravel}.{$blacklistgroup}.{this.assignedcontrolled}">
+          <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+            text="'    skipping blacklisted sector=' + $secCand.knownname" append="true"/>
+          <continue/>
+        </do_if>
+        <set_value name="$raw" exact="$secCand.yieldrating.{$ware}"/>
+        <do_if value="$raw le 0">
+          <continue/>
+        </do_if>
+        <set_value name="$scoreTable.{$secCand}" exact="(-1.0f) * ($raw / (1.0f + ($gdTable.{$secCand})f * $miningDistanceFactor))"/>
+      </do_for_each>
+      <remove_value name="$gdTable"/>
+
+      <set_value name="$shortlist" exact="$scoreTable.keys.list"/>
+      <sort_list list="$shortlist" sortbyvalue="$scoreTable.{loop.element}"/>
+
+      <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+        text="'  WarehouseFleetMine: ' + $shortlist.count + ' scored sector(s) for ' + $ware + ' (factor=' + $miningDistanceFactor + ', will try up to ' + [$miningSectorRetries, $shortlist.count].min + ')'" append="true"/>
+
+      <!-- Walk the top-scored sectors, randomized floor + relaxed fallback on each.
+           Deliberately find_resource, NOT find_closest_resource: the closest-variant is
+           deterministic for a given start position, so a fleet of miners all launching from the
+           same warehouse converges on the same patch; even the randomized minrating floor does
+           not break that up, because "closest patch above the floor" is still the same patch for
+           everyone. find_resource picks among qualifying patches, which spreads the fleet. -->
+      <set_value name="$foundSector" exact="null"/>
+      <set_value name="$foundPos" exact="null"/>
+      <set_value name="$attempts" exact="0"/>
+      <set_value name="$maxAttempts" exact="[$miningSectorRetries, $shortlist.count].min"/>
+      <do_for_each in="$shortlist" name="$trySector">
+        <do_if value="$attempts ge $maxAttempts">
+          <break/>
+        </do_if>
+        <set_value name="$attempts" operation="add"/>
+
+        <set_value name="$bestRaw" exact="$trySector.yieldrating.{$ware}"/>
+        <set_value name="$R" min="$miningFloorRatioMin" max="$miningFloorRatioMax"/>
+        <set_value name="$floor1" exact="($bestRaw)f * $R"/>
+
+        <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+          text="'    attempt ' + $attempts + '/' + $maxAttempts + ' sector=' + $trySector.knownname + ' score=' + ((-1.0f) * $scoreTable.{$trySector}) + ' raw=' + $bestRaw + ' R=' + $R + ' floor=' + $floor1" append="true"/>
+
+        <find_resource resourcearea="$resourcearea" ware="$ware" sector="$foundSector" position="$foundPos" refobject="$trySector" minrating="$floor1"/>
+
+        <!-- Same-sector fallback: nothing met the random floor; relax it once. -->
+        <do_if value="not @$resourcearea.exists">
+          <set_value name="$floor2" exact="$floor1 * $miningFloorRelaxDiv"/>
+          <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+            text="'      no patch met floor; retrying same sector at lower floor=' + $floor2" append="true"/>
+          <find_resource resourcearea="$resourcearea" ware="$ware" sector="$foundSector" position="$foundPos" refobject="$trySector" minrating="$floor2"/>
+          <remove_value name="$floor2"/>
+        </do_if>
+
+        <remove_value name="$bestRaw"/>
+        <remove_value name="$R"/>
+        <remove_value name="$floor1"/>
+
+        <do_if value="@$resourcearea.exists and @$foundSector">
+          <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+            text="'  WarehouseFleetMine: chose ' + $foundSector.knownname + ' (attempt ' + $attempts + '/' + $maxAttempts + ') for ' + $ware" append="true"/>
+          <break/>
+        </do_if>
+      </do_for_each>
+
+      <!-- Unlucky fallback: no minrating, run against the top-scored sector. Last resort.
+           Here find_closest_resource IS the right tool - unlike the loop above, the goal is no
+           longer spreading ships across patches (there is apparently nothing decent to spread
+           over), but a guaranteed pick of whatever exists, and deterministic-closest maximizes
+           the chance of finding it and minimizes the flight there. -->
+      <do_if value="(not @$resourcearea.exists or not @$foundSector) and $shortlist.count gt 0">
+        <set_value name="$topSec" exact="$shortlist.{1}"/>
+        <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+          text="'    unlucky fallback: no patch found in top ' + $maxAttempts + ' sectors; retrying ' + $topSec.knownname + ' with no minrating'" append="true"/>
+        <create_position name="$searchPos" space="$topSec" value="$topSec.coreposition"/>
+        <find_closest_resource resourcearea="$resourcearea" ware="$ware" sector="$foundSector" position="$foundPos" refobject="$topSec">
+          <refposition value="$searchPos" object="$topSec"/>
+        </find_closest_resource>
+        <remove_value name="$searchPos"/>
+        <remove_value name="$topSec"/>
+      </do_if>
+
+      <remove_value name="$scoreTable"/>
+      <remove_value name="$shortlist"/>
+      <remove_value name="$attempts"/>
+      <remove_value name="$maxAttempts"/>
+      <remove_value name="$miningDistanceFactor"/>
+      <remove_value name="$miningFloorRatioMin"/>
+      <remove_value name="$miningFloorRatioMax"/>
+      <remove_value name="$miningFloorRelaxDiv"/>
+      <remove_value name="$miningSectorRetries"/>
+
+      <do_if value="not @$resourcearea.exists or not @$foundSector">
+        <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+          text="'  WarehouseFleetMine: no resource area found for ' + $ware + ' within ' + $maxGateDistance + ' gate(s) of ' + $anchorSector.knownname + '; aborting'" append="true"/>
+        <return/>
+      </do_if>
+
+      <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+        text="'[' + player.age + '] WarehouseFleetMine: dispatching MiningCollect for ' + $ware + ' in ' + $foundSector.knownname" append="true"/>
+
+      <create_order name="$miningcollect" object="this.assignedcontrolled" id="'MiningCollect'" immediate="true">
+        <param name="destination" value="[$foundSector, $foundPos]"/>
+        <param name="ware" value="$ware"/>
+        <param name="secwares" value="[]"/>
+        <param name="resourcearea" value="@$resourcearea"/>
+        <param name="internalorder" value="true"/>
+        <param name="debugchance" value="$debugchance"/>
+      </create_order>
+
+      <wait exact="1ms"/>
+
+      <label name="finish"/>
+
+      <do_if value="@$resourcearea.exists">
+        <remove_yield_reservation reserver="this.assignedcontrolled" resourcearea="$resourcearea"/>
+      </do_if>
+
+      <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+        text="'[' + player.age + '] WarehouseFleetMine: reached finish label; cargo-now=' + this.ship.cargo.{$ware}.count + ' ' + $ware + ' (max ' + this.ship.cargo.{$ware}.max + ')'" append="true"/>
+      <return/>
+    </actions>
+  </attention>
+
+  <on_abort>
+    <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
+      text="'[' + player.age + '] WarehouseFleetMine: on_abort fired'" append="true"/>
+    <do_if value="not $miningcollect? and @$resourcearea.exists and this.assignedcontrolled">
+      <remove_yield_reservation reserver="this.assignedcontrolled" resourcearea="$resourcearea"/>
+    </do_if>
+  </on_abort>
+</aiscript>

--- a/aiscripts/order.warehousefleet.mining.xml
+++ b/aiscripts/order.warehousefleet.mining.xml
@@ -2,23 +2,28 @@
 <aiscript name="order.warehousefleet.mining" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="aiscripts.xsd" version="1">
 
   <!--
-    One-shot mining order issued by the WarehouseFleet idle-mining fallback.
+    One-shot mining order dispatched by the WarehouseFleet scheduler when a mining trip wins the
+    importance/rating competition (see prioMining and FindMiningCandidate in md/warehousefleets.xml).
 
     Why this exists: vanilla MiningRoutine is an infinite loop (mine -> sell -> mine -> ...).
     Even with maxsell=0 and a duration cap, the inner AutoMine sub-order keeps the ship cycling,
-    which conflicts with the WarehouseFleet delivery flow (supply-target first, then home
-    warehouse, then the configured cargo emptying routine).
+    which conflicts with the WarehouseFleet delivery flow (sell to the home warehouse, let the
+    next scheduling round decide where the ware is needed).
 
     What this does: find a resource area for the chosen ware near the anchor sector, reserve it,
     dispatch a single MiningCollect sub-order (the same leaf order vanilla mining uses), wait
     for it to end (cargo full or area depleted), release the reservation, and END. No selling,
     no looping. The ship then returns to its default behaviour (WarehouseFleet), whose scheduler
-    picks up the cargo on the next cycle and routes it through DeliverMinedCargoOrFallback.
+    picks up the cargo on the next cycle and sells it to the home warehouse.
+
+    Recall: the MD-side MiningOpWatcher cancels the MiningCollect sub-order when the trip stops
+    making progress; this script then resumes from its wait, releases the reservation and ends
+    normally with whatever cargo was gathered.
   -->
 
-  <order id="WarehouseFleetMine" name="WarehouseFleet Mining" description="One-shot mining for the WarehouseFleet idle-mining fallback." category="internal" allowinloop="false">
+  <order id="WarehouseFleetMine" name="WarehouseFleet Mining" description="One-shot mining trip for the WarehouseFleet behaviour." category="internal" allowinloop="false">
     <params>
-      <param name="ware" required="true" type="ware" text="Ware to mine" comment="The single ware to gather. Picked by PickMiningWare in the MD scheduler.">
+      <param name="ware" required="true" type="ware" text="Ware to mine" comment="The single ware to gather. Picked by FindMiningCandidate in the MD scheduler.">
         <input_param name="cancarry" value="this.ship"/>
         <input_param name="isminable" value="true"/>
       </param>
@@ -28,13 +33,9 @@
         <input_param name="max" value="10"/>
         <input_param name="step" value="1"/>
       </param>
-      <!-- $debugchance must exist in this script's scope: the vanilla interrupt handlers below
-           (e.g. interrupt.inspected) execute their actions in the interrupted script's variable
-           scope and read $debugchance unguarded. Without this param, every inspection event on a
-           ship running this order raises "Property lookup failed: $debugchance". -->
-      <param name="debugchance" type="bool" default="0" advanced="true" text="Debug">
-        <input_param name="truevalue" value="100"/>
-      </param>
+      <param name="cooldownKey" default="null" type="internal" text="Mining cooldown key"/>
+      <!-- needed to avoid error messages when interrupts trigger during the run_script part -->
+      <param name="debugchance" default="0" type="internal" text="Debug chance"/>
     </params>
     <requires primarypurpose="purpose.mine"/>
     <!-- condition="false" suppresses the map marker entirely. Without this, even an internal-
@@ -218,8 +219,13 @@
       <do_if value="not @$resourcearea.exists or not @$foundSector">
         <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
           text="'  WarehouseFleetMine: no resource area found for ' + $ware + ' within ' + $maxGateDistance + ' gate(s) of ' + $anchorSector.knownname + '; aborting'" append="true"/>
+        <!-- Fire MiningResourceNotFound event to make sure miningCooldown is applied -->
+        <signal_objects object="player.entity" param="'WarehouseFleets'" param2="'MiningResourceNotFound'" param3="$cooldownKey"/>
         <return/>
       </do_if>
+
+      <!-- Reserve the selected resource area while MiningCollect is running -->
+      <add_yield_reservation reserver="this.assignedcontrolled" resourcearea="$resourcearea"/>
 
       <debug_to_file chance="100" name="this.ship.idcode" directory="'WarehouseFleets'"
         text="'[' + player.age + '] WarehouseFleetMine: dispatching MiningCollect for ' + $ware + ' in ' + $foundSector.knownname" append="true"/>

--- a/aiscripts/order.warehousefleet.xml
+++ b/aiscripts/order.warehousefleet.xml
@@ -44,6 +44,13 @@
         <input_param name="max" value="10" />
         <patch sinceversion="42" value="7" />
       </param>
+      <!-- sinceversion 45 - jump ahead [START]. This is placed here for cohesion between similiar parameters -->
+      <param name="prioMining" default="global.$WarehouseFleets.$prioMining" type="number" text="Prio: Mining">
+        <input_param name="min" value="0" />
+        <input_param name="max" value="10" />
+        <patch sinceversion="45" value="global.$WarehouseFleets.$prioMining" />
+      </param>
+      <!-- sinceversion 45 - jump ahead [END]. -->
       <param name="minCargoUsage" default="global.$WarehouseFleets.$minCargoUsage" type="number" text="Min. Cargo Usage (%)">
         <input_param name="min" value="0" />
         <input_param name="max" value="90" />
@@ -68,10 +75,6 @@
         <patch sinceversion="44" value="0" />
       </param>
 
-      <!-- idle mining fallback (only relevant for ships with solid/liquid cargo, i.e. miners) -->
-      <param name="miningFallback" type="bool" default="false" text="Mine When Idle">
-        <patch sinceversion="45" value="false" />
-      </param>
       <param name="miningMaxGateDistance" default="3" type="number" text="Mining: Max Gate Distance">
         <input_param name="min" value="0" />
         <input_param name="max" value="10" />

--- a/aiscripts/order.warehousefleet.xml
+++ b/aiscripts/order.warehousefleet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<aiscript name="WarehouseFleet" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/manuel/Nextcloud/X4 Foundations/2026-02-28/libraries/aiscripts.xsd" version="44">
+<aiscript name="WarehouseFleet" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="/home/manuel/Nextcloud/X4 Foundations/2026-02-28/libraries/aiscripts.xsd" version="45">
 
   <order id="WarehouseFleet" name="WarehouseFleet" description="Warehouse Fleet" category="trade" infinite="true">
     <params>
@@ -66,6 +66,17 @@
       <param name="debugchance" default="0" type="internal" text="debugchance">
         <!-- needed to avoid error messages when interrupts trigger during the run_script part -->
         <patch sinceversion="44" value="0" />
+      </param>
+
+      <!-- idle mining fallback (only relevant for ships with solid/liquid cargo, i.e. miners) -->
+      <param name="miningFallback" type="bool" default="false" text="Mine When Idle">
+        <patch sinceversion="45" value="false" />
+      </param>
+      <param name="miningMaxGateDistance" default="3" type="number" text="Mining: Max Gate Distance">
+        <input_param name="min" value="0" />
+        <input_param name="max" value="10" />
+        <input_param name="step" value="1" />
+        <patch sinceversion="45" value="3" />
       </param>
     </params>
 

--- a/libraries/icons.xml
+++ b/libraries/icons.xml
@@ -6,4 +6,7 @@
   <add sel="/icons">
     <icon name="order_returntowarehouse" texture="assets\textures\ui\order\order_movetoobject.tga" height="32" width="32"></icon>
   </add>
+  <add sel="/icons">
+    <icon name="order_warehousefleetmine" texture="assets\textures\ui\order\order_miningroutine.tga" height="32" width="32"></icon>
+  </add>
 </diff>

--- a/md/warehousefleets.xml
+++ b/md/warehousefleets.xml
@@ -30,7 +30,7 @@
         <set_value name="global.$WarehouseFleets.$waitInDockL" exact="false" />
         <set_value name="global.$WarehouseFleets.$minCargoUsage" exact="50" />
         <set_value name="global.$WarehouseFleets.$tradeGatePenalty" exact="20" />
-        <set_value name="global.$WarehouseFleets.$miningFallbackIdleSeconds" exact="60" />
+        <set_value name="global.$WarehouseFleets.$prioMining" exact="4" />
       </actions>
 
       <patch sinceversion="6">
@@ -80,8 +80,8 @@
       </patch>
 
       <patch sinceversion="8">
-        <do_if value="@global.$WarehouseFleets.$miningFallbackIdleSeconds == null">
-          <set_value name="global.$WarehouseFleets.$miningFallbackIdleSeconds" exact="60" />
+        <do_if value="@global.$WarehouseFleets.$prioMining == null">
+          <set_value name="global.$WarehouseFleets.$prioMining" exact="4" />
         </do_if>
       </patch>
     </cue>
@@ -99,13 +99,8 @@
         <set_value name="$version" exact="16" />
         <debug_to_file chance="100" name="'config'" directory="'WarehouseFleets'" text="'Initialize Warehouse Fleets Mod, Version = ' + $version" output="false" append="true" />
         <set_value name="$deliveries" exact="[]" />
-        <!-- Idle-mining bookkeeping. $miningOps holds in-flight mining dispatches so the scheduler
-             can reserve warehouse space against ships that are out mining right now. $idleSince is
-             a per-ship clock tracking how long the scheduler has seen "no trade found", so mining
-             is not dispatched the instant a trade window briefly closes. Cleaned up by the
-             GarbageCollector cue. -->
-        <set_value name="$miningOps" exact="[]" />
-        <set_value name="$idleSince" exact="table[]" />
+        <!-- station/ware keys of recently failed mining dispatches; FindMiningCandidate skips them -->
+        <set_value name="$miningCooldowns" exact="table[]" />
         <signal_cue cue="ShipInitializer" check="false" comment="check=false, da es den Cue erst nach den actions gibt" />
       </actions>
       <cues>
@@ -143,15 +138,23 @@
           <actions>
             <set_value name="$ship" exact="event.param3" />
             <set_value name="$deliveries" exact="parent.$deliveries" />
-            <set_value name="$miningOps" exact="parent.$miningOps" />
-            <set_value name="$idleSince" exact="parent.$idleSince" />
+            <set_value name="$miningCooldowns" exact="parent.$miningCooldowns" />
             <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'" text="'Schedule request received for ship ' + $ship.idcode" output="false" append="true" />
             <run_actions ref="WarehouseFleetScheduler">
               <param name="ship" value="$ship" />
               <param name="deliveries" value="$deliveries" />
-              <param name="miningOps" value="$miningOps" />
-              <param name="idleSince" value="$idleSince" />
+              <param name="miningCooldowns" value="$miningCooldowns" />
             </run_actions>
+          </actions>
+        </cue>
+
+        <cue name="MiningFailureListener" instantiate="true">
+          <conditions>
+            <event_object_signalled object="player.entity" param="'WarehouseFleets'" param2="'MiningResourceNotFound'" />
+          </conditions>
+          <actions>
+            <set_value name="$miningCooldowns" exact="parent.$miningCooldowns" />
+            <set_value name="$miningCooldowns.{event.param3}" exact="player.age" />
           </actions>
         </cue>
 
@@ -166,8 +169,7 @@
           <actions>
             <set_value name="$ship" exact="if event.name == 'event_player_built_ship' then event.param else event.param3" />
             <set_value name="$deliveries" exact="parent.$deliveries" />
-            <set_value name="$miningOps" exact="parent.$miningOps" />
-            <set_value name="$idleSince" exact="parent.$idleSince" />
+            <set_value name="$miningCooldowns" exact="parent.$miningCooldowns" />
             <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'" text="'Registered ship: ' + $ship.idcode" output="false" append="true" />
           </actions>
           <cues>
@@ -201,8 +203,7 @@
                     <run_actions ref="WarehouseFleetScheduler">
                       <param name="ship" value="$ship" />
                       <param name="deliveries" value="$deliveries" />
-                      <param name="miningOps" value="$miningOps" />
-                      <param name="idleSince" value="$idleSince" />
+                      <param name="miningCooldowns" value="$miningCooldowns" />
                     </run_actions>
                   </actions>
                 </cue>
@@ -267,6 +268,110 @@
           </cues>
         </cue>
 
+        <!-- Watches an in-flight mining trip and recalls the ship when the trip stops making
+             progress (exhausted resource fields would otherwise lock the ship up indefinitely).
+             Signalled by the scheduler on every mining dispatch. -->
+        <cue name="MiningOpWatcher" instantiate="true" namespace="this">
+          <conditions>
+            <event_cue_signalled />
+          </conditions>
+          <actions>
+            <set_value name="$ship" exact="event.param.$ship" />
+            <set_value name="$mineOrder" exact="event.param.$mineOrder" />
+            <set_value name="$ware" exact="event.param.$ware" />
+            <set_value name="$delivery" exact="event.param.$delivery" comment="the mining reservation record in the global deliveries list" />
+            <set_value name="$lastCargo" exact="$ship.cargo.{$ware}.count" />
+            <set_value name="$stagnantChecks" exact="0" />
+            <set_value name="$arrivedAt" exact="null" />
+          </actions>
+          <cues>
+            <cue name="MiningOpWatch">
+              <cues>
+
+                <!-- Fires once when the ship starts collecting -->
+                <cue name="MiningOpArrivalWatch" checkinterval="30">
+                  <conditions>
+                    <check_value value="$ship.exists and $ship.cargo.{$ware}.count gt $lastCargo" />
+                  </conditions>
+                  <actions>
+                    <set_value name="$arrivedAt" exact="player.age" />
+                    <set_value name="$lastCargo" exact="$ship.cargo.{$ware}.count" />
+                  </actions>
+                </cue>
+
+                <!-- Ends the watch when the trip is over; releases the reservation if the trip brought
+                     nothing back. Also owns the 25min hard cap (covers trips that never arrive; kept
+                     below the GarbageCollector's 30min purge so the record survives until delivery). -->
+                <cue name="MiningOpDoneWatcher" checkinterval="5">
+                  <conditions>
+                    <check_any>
+                      <check_value value="not $ship.exists or not $mineOrder.exists" />
+                      <check_value value="player.age gt ($delivery.$timeScheduled + 1500)" />
+                    </check_any>
+                  </conditions>
+                  <actions>
+                    <!-- Hard cap hit while the trip still runs: recall -->
+                    <do_if value="$ship.exists and $mineOrder.exists">
+                      <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+                        text="'  MiningOpWatcher: 25min hard cap, recalling miner (cargo=' + $ship.cargo.{$ware}.count + '/' + $delivery.$amount + ')'" output="false" append="true" />
+                      <!-- Cancelling the MiningCollect leaf lets the parent order end normally -->
+                      <do_if value="@$ship.order.id == 'MiningCollect'">
+                        <cancel_order order="$ship.order" />
+                      </do_if>
+                      <do_else>
+                        <cancel_order order="$mineOrder" />
+                      </do_else>
+                    </do_if>
+                    <!-- Release the reservation if the load never became a delivery and nothing is aboard -->
+                    <do_if value="$delivery.$receiverOrder == null and $delivery.$timeFinished == null and not @$ship.cargo.{$ware}.count">
+                      <set_value name="$delivery.$timeFinished" exact="player.age" />
+                    </do_if>
+                    <cancel_cue cue="MiningOpWatch" />
+                  </actions>
+                </cue>
+
+                <cue name="MiningOpHealthCheck" instantiate="true" checkinterval="120">
+                  <conditions>
+                    <check_value value="$ship.exists and $mineOrder.exists and $arrivedAt != null and player.age gt ($arrivedAt + 120)" />
+                  </conditions>
+                  <actions>
+                    <set_value name="$cargoNow" exact="$ship.cargo.{$ware}.count" />
+                    <set_value name="$gained" exact="$cargoNow - $lastCargo" />
+                    <set_value name="$lastCargo" exact="$cargoNow" />
+                    <!-- less than 5% of a full load gained since the last check counts as stagnant -->
+                    <do_if value="$gained * 20 lt $delivery.$amount">
+                      <set_value name="$stagnantChecks" operation="add" />
+                    </do_if>
+                    <do_else>
+                      <set_value name="$stagnantChecks" exact="0" />
+                    </do_else>
+                    <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+                      text="'  MiningOpWatcher: ware=' + $ware + ' cargo=' + $cargoNow + ' gained=' + $gained + ' stagnantChecks=' + $stagnantChecks" output="false" append="true" />
+                    <!-- two consecutive stagnant checks -->
+                    <do_if value="$stagnantChecks ge 2">
+                      <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+                        text="'  MiningOpWatcher: recalling miner (cargo=' + $cargoNow + '/' + $delivery.$amount + ', tripTime=' + (player.age - $delivery.$timeScheduled) + 's)'" output="false" append="true" />
+                      <!-- Cancelling the MiningCollect leaf lets the parent order end normally -->
+                      <do_if value="@$ship.order.id == 'MiningCollect'">
+                        <cancel_order order="$ship.order" />
+                      </do_if>
+                      <do_else>
+                        <cancel_order order="$mineOrder" />
+                      </do_else>
+                      <!-- No actual delivery order was created and the ship has zero cargo - neutralize the delivery entry -->
+                      <do_if value="$delivery.$receiverOrder == null and $delivery.$timeFinished == null and not @$ship.cargo.{$ware}.count">
+                        <set_value name="$delivery.$timeFinished" exact="player.age" />
+                      </do_if>
+                      <cancel_cue cue="MiningOpWatch" />
+                    </do_if>
+                  </actions>
+                </cue>
+
+              </cues>
+            </cue>
+          </cues>
+        </cue>
+
         <!-- Entfernt regelmäßig alte Deliveries aus der globalen Liste -->
         <cue name="GarbageCollector" checkinterval="30" instantiate="true">
           <actions>
@@ -281,38 +386,6 @@
               <debug_to_file chance="100" name="'garbage-collector'" directory="'WarehouseFleets'" text="$delivery" output="false" append="true" />
             </do_for_each>
 
-            <!-- Idle-mining bookkeeping cleanup.
-                 - Drop $miningOps entries older than 35min (analogous to the delivery assumption
-                   above: a mining trip is assumed to be done after 30min, 35 is a safe buffer).
-                   Normal cleanup happens in DeliverMinedCargoOrFallback when the cargo arrives;
-                   this is the safety net for ships that died mid-mining or had their default
-                   behaviour changed. -->
-            <set_value name="$miningOps" exact="parent.$miningOps" />
-            <set_value name="$opsToRemove" exact="[]" />
-            <do_for_each in="$miningOps" name="$op">
-              <do_if value="$op.$startedAt lt (player.age - 2100)" comment="2100s = 35min">
-                <append_to_list name="$opsToRemove" exact="$op" />
-              </do_if>
-            </do_for_each>
-            <do_for_each in="$opsToRemove" name="$op">
-              <remove_from_list name="$miningOps" exact="$op" />
-            </do_for_each>
-            <debug_to_file chance="100" name="'garbage-collector'" directory="'WarehouseFleets'" text="$miningOps.count + ' MiningOps:'" output="false" append="true" />
-            <do_for_each in="$miningOps" name="$op">
-              <debug_to_file chance="100" name="'garbage-collector'" directory="'WarehouseFleets'" text="$op" output="false" append="true" />
-            </do_for_each>
-
-            <!-- Idle clock cleanup: drop entries whose ship is gone. -->
-            <set_value name="$idleSince" exact="parent.$idleSince" />
-            <set_value name="$idleKeysToRemove" exact="[]" />
-            <do_for_each in="$idleSince.keys.list" name="$idleShip">
-              <do_if value="not $idleShip.exists">
-                <append_to_list name="$idleKeysToRemove" exact="$idleShip" />
-              </do_if>
-            </do_for_each>
-            <do_for_each in="$idleKeysToRemove" name="$idleShip">
-              <remove_value name="$idleSince.{$idleShip}" />
-            </do_for_each>
           </actions>
         </cue>
 
@@ -325,8 +398,7 @@
       <params>
         <param name="ship" />
         <param name="deliveries" />
-        <param name="miningOps" />
-        <param name="idleSince" />
+        <param name="miningCooldowns" />
       </params>
       <actions>
         <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'==============================='" output="false" append="false" />
@@ -346,22 +418,15 @@
           <transfer_money from="$sourceStation" to="faction.player" amount="$moneyToTransfer" />
         </do_if>
 
-        <!-- Schiff leer machen, falls noch Ladung vorhanden.
-             Mining-capable ships (solid/liquid cargo) route through DeliverMinedCargoOrFallback
-             instead, so mined cargo gets properly delivered: supply targets first, then the home
-             warehouse via a real trade order, and only then the configured $failedOrderHandling
-             (refund/teleport/...). Container-only ships keep the original EmptyCargoRoutine path
-             unchanged. -->
+        <!-- Schiff leer machen, falls noch Ladung vorhanden -->
         <set_value name="$cargo" exact="$ship.cargo.list" />
         <do_if value="$cargo.count gt 0">
           <do_if value="$ship.cargo.capacity.solid gt 0 or $ship.cargo.capacity.liquid gt 0">
             <run_actions ref="DeliverMinedCargoOrFallback">
               <param name="ship" value="$ship" />
               <param name="cargo" value="$cargo" />
-              <param name="order" value="$order" />
               <param name="warehouse" value="$sourceStation" />
               <param name="deliveries" value="$deliveries" />
-              <param name="miningOps" value="$miningOps" />
             </run_actions>
             <return comment="delivery orders (if any) were created; do not also schedule trades this cycle" />
           </do_if>
@@ -454,23 +519,58 @@
           <param name="receiver" value="null" />
         </run_actions>
 
-        <do_if value="$bestPushTrip == null and $bestPullTrip == null">
-          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'No trade found that meets minimum cargo usage requirement'" output="false" append="true" />
-          <run_actions ref="TryMiningFallback">
-            <param name="ship" value="$ship" />
-            <param name="order" value="$order" />
-            <param name="sourceStation" value="$sourceStation" />
-            <param name="miningOps" value="$miningOps" />
-            <param name="idleSince" value="$idleSince" />
-          </run_actions>
+        <!-- Mining candidate (null when prioMining is 0, the ship cannot mine, or nothing needs stock) -->
+        <run_actions ref="FindMiningCandidate" result="$miningCandidate">
+          <param name="ship" value="$ship" />
+          <param name="order" value="$order" />
+          <param name="sourceStation" value="$sourceStation" />
+          <param name="deliveries" value="$deliveries" />
+          <param name="miningCooldowns" value="$miningCooldowns" />
+        </run_actions>
+
+        <do_if value="$miningCandidate != null and $miningCandidate.$rating gt ([@$bestPushTrip.$rating + 0, @$bestPullTrip.$rating + 0].max)">
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+            text="'Mining beats trips: ' + $miningCandidate + ' vs push=' + @$bestPushTrip.$rating + ' pull=' + @$bestPullTrip.$rating" output="false" append="true" />
+          <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'"
+            text="'Mining dispatch: ship=' + $ship.idcode + ' ware=' + $miningCandidate.$ware + ' rating=' + '%.3s'.[$miningCandidate.$rating] + ' anchor=' + $sourceStation.sector.knownname + ' maxGateDist=' + $order.$miningMaxGateDistance" output="false" append="true" />
+
+          <!-- Incoming reservation in the shared deliveries ledger; receiverOrder is filled in by
+               DeliverMinedCargoOrFallback when the mined cargo becomes a real trade order -->
+          <set_value name="$miningDelivery" exact="table[
+            $shipID = $ship.idcode,
+            $timeScheduled = player.age,
+            $timeFinished = null,
+            $wareID = $miningCandidate.$ware.id,
+            $ware = $miningCandidate.$ware,
+            $amount = $miningCandidate.$amount,
+            $providerID = $ship.idcode,
+            $receiverID = $sourceStation.idcode,
+            $providerOrder = null,
+            $receiverOrder = null,
+            $isMiningOp = true,
+          ]" />
+          <append_to_list name="$deliveries" exact="$miningDelivery" />
+
+          <create_order name="$mineOrder" id="'WarehouseFleetMine'" object="$ship">
+            <param name="ware" value="$miningCandidate.$ware" />
+            <param name="anchorSector" value="$sourceStation.sector" />
+            <param name="maxGateDistance" value="$order.$miningMaxGateDistance" />
+            <param name="cooldownKey" value="'$' + $sourceStation.idcode + '-' + $miningCandidate.$ware.id" />
+          </create_order>
+
+          <!-- Watcher recalls the ship if the trip stops making progress (exhausted fields). -->
+          <signal_cue_instantly cue="MiningOpWatcher" param="table[
+            $ship = $ship,
+            $mineOrder = $mineOrder,
+            $ware = $miningCandidate.$ware,
+            $delivery = $miningDelivery,
+          ]" />
           <return />
         </do_if>
 
-        <!-- A trade WAS found - the ship gets real work this cycle. Clear the idle clock so a
-             future "no trade" doesn't immediately count the current idleness against the
-             mining-fallback threshold. -->
-        <do_if value="$idleSince.{$ship}?">
-          <remove_value name="$idleSince.{$ship}" />
+        <do_if value="$bestPushTrip == null and $bestPullTrip == null">
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'No trade found that meets minimum cargo usage requirement'" output="false" append="true" />
+          <return />
         </do_if>
 
         <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'Best Push Trip: ' + $bestPushTrip" output="false" append="true" />
@@ -639,10 +739,15 @@
         <do_for_each in="$deliveries" name="$delivery">
           <set_value name="$providerKey" exact="'$' + $delivery.$providerID + '/' + $delivery.$wareID" />
           <set_value name="$receiverKey" exact="'$' + $delivery.$receiverID + '/' + $delivery.$wareID" />
-          <do_if value="$delivery.$providerOrder.exists">
+          <!-- In-flight mining trip: incoming at its home warehouse -->
+          <do_if value="@$delivery.$isMiningOp and $delivery.$receiverOrder == null and $delivery.$timeFinished == null">
+            <set_value operation="add" name="$reservations.{$receiverKey}" exact="$delivery.$amount" />
+            <continue />
+          </do_if>
+          <do_if value="@$delivery.$providerOrder.exists">
             <set_value operation="subtract" name="$reservations.{$providerKey}" exact="$delivery.$amount" />
           </do_if>
-          <do_if value="$delivery.$receiverOrder.exists">
+          <do_if value="@$delivery.$receiverOrder.exists">
             <set_value operation="add" name="$reservations.{$receiverKey}" exact="$delivery.$amount" />
           </do_if>
         </do_for_each>
@@ -969,144 +1074,45 @@
       </actions>
     </library>
 
-    <!-- ============================================================================================
-         Idle-mining fallback libraries.
-         Used when the scheduler finds no eligible trade for a mining-capable ship and the per-ship
-         idle timer has expired. Picks an under-stocked solid/liquid ware the home warehouse buys,
-         reserves the projected delivery against in-flight mining ops, and dispatches the one-shot
-         WarehouseFleetMine order (aiscripts/order.warehousefleet.mining.xml). After mining ends,
-         the WarehouseFleet attention cycle resumes, the scheduler sees cargo aboard, and
-         DeliverMinedCargoOrFallback routes it into a useful destination.
-         ============================================================================================ -->
+    <!-- Mining libraries -->
 
-    <library name="TryMiningFallback" purpose="run_actions" namespace="this">
+    <library name="FindMiningCandidate" purpose="run_actions" namespace="this">
       <params>
         <param name="ship" />
         <param name="order" />
         <param name="sourceStation" />
-        <param name="miningOps" />
-        <param name="idleSince" />
+        <param name="deliveries" />
+        <param name="miningCooldowns" comment="station/ware keys of recently failed dispatches" />
       </params>
       <actions>
-        <!-- Per-fleet opt-in. -->
-        <do_if value="not $order.$miningFallback">
-          <return />
+        <!-- prioMining = 0 disables mining entirely (no separate switch needed). -->
+        <do_if value="$order.$prioMining le 0">
+          <return value="null" />
         </do_if>
 
-        <!-- Ship must be mining-capable: solid or liquid cargo capacity. -->
-        <do_if value="$ship.cargo.capacity.solid le 0 and $ship.cargo.capacity.liquid le 0">
-          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  MiningFallback: ship has no solid/liquid cargo (container-only); skip'" append="true" />
-          <return />
-        </do_if>
-
-        <!-- "Idle" really means idle. If the ship has any active order (e.g. mid-trade, or just
-             pre-planned via ScheduleFollowUpTripWhenDocking while still selling), treat it as
-             busy: clear the idle clock and don't dispatch mining. Otherwise the idle clock ticks
-             forward while the ship is executing a delivery and mining fires right after a trade
-             completes. -->
-        <do_if value="$ship.orders.count gt 0">
-          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  MiningFallback: ship has ' + $ship.orders.count + ' active order(s); not idle, clearing timer'" append="true" />
-          <do_if value="$idleSince.{$ship}?">
-            <remove_value name="$idleSince.{$ship}" />
-          </do_if>
-          <return />
-        </do_if>
-
-        <!-- Idle clock: start it on first observation, then check against the threshold on
-             subsequent scheduler runs. -->
-        <do_if value="not $idleSince.{$ship}?">
-          <set_value name="$idleSince.{$ship}" exact="player.age" />
-          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  MiningFallback: starting idle clock at age=' + player.age" append="true" />
-          <return />
-        </do_if>
-
-        <set_value name="$idleFor" exact="player.age - $idleSince.{$ship}" />
-        <do_if value="$idleFor lt global.$WarehouseFleets.$miningFallbackIdleSeconds">
-          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  MiningFallback: idle for ' + $idleFor + 's, threshold=' + global.$WarehouseFleets.$miningFallbackIdleSeconds + 's; still warming up'" append="true" />
-          <return />
-        </do_if>
-
-        <!-- Pick the most under-stocked mineable ware the warehouse buys (and has room for, after
-             accounting for in-flight reservations). -->
-        <run_actions ref="PickMiningWare" result="$pickedWare">
-          <param name="ship" value="$ship" />
-          <param name="sourceStation" value="$sourceStation" />
-          <param name="miningOps" value="$miningOps" />
-        </run_actions>
-
-        <do_if value="$pickedWare == null">
-          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  MiningFallback: no suitable ware to mine; remaining idle'" append="true" />
-          <return />
-        </do_if>
-
-        <!-- Record the op so concurrent scheduler runs reserve room against this ship's projected arrival. -->
-        <set_value name="$shipMaxUnits" exact="
-          if $pickedWare.waretransport == waretransport.solid then ($ship.cargo.capacity.solid / $pickedWare.volume)i
-          else if $pickedWare.waretransport == waretransport.liquid then ($ship.cargo.capacity.liquid / $pickedWare.volume)i
-          else 0
-        " />
-        <append_to_list name="$miningOps" exact="table[
-          $shipID = $ship.idcode,
-          $warehouseID = $sourceStation.idcode,
-          $wareID = $pickedWare.id,
-          $ware = $pickedWare,
-          $expectedAmount = $shipMaxUnits,
-          $startedAt = player.age,
-        ]" />
-
-        <!-- Reset idle clock - the ship is getting something to do now. -->
-        <remove_value name="$idleSince.{$ship}" />
-
-        <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
-          text="'  MiningFallback: dispatching WarehouseFleetMine for ' + $pickedWare + ' (max ~' + $shipMaxUnits + ' units), anchor=' + $sourceStation.sector.knownname" append="true" />
-        <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'"
-          text="'MiningFallback dispatch: ship=' + $ship.idcode + ' ware=' + $pickedWare + ' reserved=' + $shipMaxUnits + ' anchor=' + $sourceStation.sector.knownname + ' maxGateDist=' + $order.$miningMaxGateDistance" append="true" />
-
-        <!-- One-shot mining order (aiscripts/order.warehousefleet.mining.xml): dispatches a single
-             MiningCollect sub-order, waits for it to finish (cargo full or area depleted), and
-             ends. No selling, no looping. Afterwards the ship's default behaviour (WarehouseFleet)
-             resumes, the scheduler sees the cargo and routes it via DeliverMinedCargoOrFallback. -->
-        <create_order id="'WarehouseFleetMine'" object="$ship">
-          <param name="ware" value="$pickedWare" />
-          <param name="anchorSector" value="$sourceStation.sector" />
-          <param name="maxGateDistance" value="$order.$miningMaxGateDistance" />
-        </create_order>
-      </actions>
-    </library>
-
-    <library name="PickMiningWare" purpose="run_actions" namespace="this">
-      <params>
-        <param name="ship" />
-        <param name="sourceStation" />
-        <param name="miningOps" />
-      </params>
-      <actions>
-        <!-- Candidate ware list based on the ship's cargo capacity. Nividium is deliberately
-             excluded (warehouses rarely buy it; it is a sell-for-cash ware, not a supply ware). -->
+        <!-- Candidates: every minable ware this ship can carry (dynamic, so modded resources work) -->
+        <get_ware_definition result="$minableWares" tags="tag.minable" />
         <create_list name="$candidates" />
-        <do_if value="$ship.cargo.capacity.solid gt 0">
-          <append_to_list name="$candidates" exact="ware.ore" />
-          <append_to_list name="$candidates" exact="ware.silicon" />
-          <append_to_list name="$candidates" exact="ware.ice" />
-        </do_if>
-        <do_if value="$ship.cargo.capacity.liquid gt 0">
-          <append_to_list name="$candidates" exact="ware.hydrogen" />
-          <append_to_list name="$candidates" exact="ware.methane" />
-          <append_to_list name="$candidates" exact="ware.helium" />
-        </do_if>
-
+        <do_for_each in="$minableWares" name="$minableWare">
+          <do_if value="$ship.cargo.{$minableWare}.max gt 0">
+            <append_to_list name="$candidates" exact="$minableWare" />
+          </do_if>
+        </do_for_each>
         <do_if value="$candidates.count == 0">
           <return value="null" />
         </do_if>
 
-        <!-- For each candidate compute: buy offer at home, current cargo, target capacity,
-             in-flight reservations from miningOps, projected post-arrival fullness. Skip
-             candidates the warehouse won't have room for; among the rest pick the most
-             under-stocked one (lowest cargo/target ratio). -->
-        <set_value name="$bestWare" exact="null" />
-        <set_value name="$bestRatio" exact="2.0" comment="anything &gt; 1.0 means 'no candidate picked yet'" />
-
+        <!-- Score each candidate ware the warehouse buys; in-flight mining ops count as stock -->
+        <set_value name="$best" exact="null" />
         <do_for_each in="$candidates" name="$ware">
+          <!-- Skip wares whose last dispatch came back empty (no minable field in range / exhausted); expired entries are dropped -->
+          <set_value name="$cooldownKey" exact="'$' + $sourceStation.idcode + '-' + $ware.id" />
+          <do_if value="@$miningCooldowns.{$cooldownKey} != null">
+            <do_if value="player.age lt ($miningCooldowns.{$cooldownKey} + 900)">
+              <continue />
+            </do_if>
+            <remove_value name="$miningCooldowns.{$cooldownKey}" />
+          </do_if>
           <!-- Does the home warehouse buy this ware? -->
           <find_buy_offer buyer="$sourceStation" wares="[$ware]" result="$wareBuyOffers" tradepartner="$ship" multiple="true" usereservations="false" excludeempty="false" />
           <do_if value="$wareBuyOffers.count == 0">
@@ -1116,49 +1122,78 @@
           <!-- Storage state. -->
           <set_value name="$wareCargo" exact="$sourceStation.cargo.{$ware}.count" />
           <set_value name="$wareTarget" exact="$sourceStation.cargo.{$ware}.target" />
+          <!-- Skip: warehouse has no storage allocation for this ware -->
           <do_if value="$wareTarget le 0">
-            <continue comment="warehouse has no storage allocation for this ware" />
-          </do_if>
-
-          <!-- Sum of in-flight reservations (other ships' projected arrivals for this ware). -->
-          <set_value name="$reserved" exact="0" />
-          <do_for_each in="$miningOps" name="$op">
-            <do_if value="$op.$warehouseID == $sourceStation.idcode and $op.$wareID == $ware.id">
-              <set_value name="$reserved" operation="add" exact="$op.$expectedAmount" />
-            </do_if>
-          </do_for_each>
-
-          <!-- This ship's own max contribution if it mined this ware. -->
-          <set_value name="$shipCapacityForWare" exact="
-            if $ware.waretransport == waretransport.solid then $ship.cargo.capacity.solid
-            else if $ware.waretransport == waretransport.liquid then $ship.cargo.capacity.liquid
-            else 0
-          " />
-          <set_value name="$shipMaxUnits" exact="($shipCapacityForWare / $ware.volume)i" />
-
-          <!-- Room exhaustion check. -->
-          <set_value name="$projected" exact="$wareCargo + $reserved + $shipMaxUnits" />
-          <do_if value="$projected ge $wareTarget">
-            <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
-              text="'  PickMiningWare: skip ' + $ware + ' (projected=' + $projected + ' &gt;= target=' + $wareTarget + '; reserved=' + $reserved + ')'" append="true" />
             <continue />
           </do_if>
 
-          <set_value name="$ratio" exact="($wareCargo)f / $wareTarget" />
-          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
-            text="'  PickMiningWare: candidate ' + $ware + ' ratio=' + '%.2s'.[$ratio] + ' (cargo=' + $wareCargo + '/' + $wareTarget + ' reserved=' + $reserved + ' shipMax=' + $shipMaxUnits + ')'" append="true" />
+          <!-- Net reservations for this ware at the warehouse, from the same ledger the transports use -->
+          <set_value name="$reserved" exact="0" />
+          <do_for_each in="$deliveries" name="$delivery">
+            <!-- Skip if current iteration's delivery has another ware -->
+            <do_if value="$delivery.$wareID != $ware.id">
+              <continue />
+            </do_if>
+            <!-- Mining trip still in flight: receiverOrder == null means its load was not yet turned
+                 into a sell-to-warehouse order, timeFinished == null means not released as failed -->
+            <do_if value="@$delivery.$isMiningOp and $delivery.$receiverOrder == null and $delivery.$timeFinished == null">
+              <do_if value="$delivery.$receiverID == $sourceStation.idcode">
+                <set_value name="$reserved" operation="add" exact="$delivery.$amount" />
+              </do_if>
+              <continue />
+            </do_if>
+            <!-- Delivery on its way TO the warehouse (its sell-to-warehouse order still runs): counts as stock -->
+            <do_if value="$delivery.$receiverID == $sourceStation.idcode and @$delivery.$receiverOrder.exists">
+              <set_value name="$reserved" operation="add" exact="$delivery.$amount" />
+            </do_if>
+            <!-- Delivery taking this ware AWAY from the warehouse (its pickup order still runs): frees room -->
+            <do_if value="$delivery.$providerID == $sourceStation.idcode and @$delivery.$providerOrder.exists">
+              <set_value name="$reserved" operation="subtract" exact="$delivery.$amount" />
+            </do_if>
+          </do_for_each>
 
-          <do_if value="$ratio lt $bestRatio">
-            <set_value name="$bestWare" exact="$ware" />
-            <set_value name="$bestRatio" exact="$ratio" />
+          <!-- Full shipload of this ware, in units -->
+          <set_value name="$shipMaxUnits" exact="$ship.cargo.{$ware}.max" />
+
+          <!-- Mining always brings home a full shipload (MiningCollect has no amount limit), so
+               the warehouse must have room for all of it -->
+          <set_value name="$room" exact="$wareTarget - $wareCargo - $reserved" />
+          <do_if value="$room lt $shipMaxUnits">
+            <continue />
+          </do_if>
+          <set_value name="$amount" exact="$shipMaxUnits" />
+
+          <!-- Same shape as the distribution importance with a full provider; zero when well stocked -->
+          <set_value name="$wareCargoRatio" exact="[[100.0 * ($wareCargo + $reserved) / $wareTarget, 100.0].min, 0.0].max" />
+          <set_value name="$importance" exact="(100.0 - $wareCargoRatio) * (1.0 - $wareCargoRatio/200.0) * ($order.$prioMining/10f)" />
+          <set_value name="$rating" exact="$importance * $amount * $ware.volume" />
+
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+            text="'  [mining ' + $ware + '] '
+              + 'importance = ' + '%.3s'.[$importance]
+              + ', rating = ' + '%.3s'.[$rating]
+              + ', wareCargoRatio = ' + '%.1s'.[$wareCargoRatio] + '%'
+              + ', wareCargo = ' + $wareCargo
+              + ', reserved = ' + $reserved
+              + ', wareTarget = ' + $wareTarget
+              + ', amount = ' + $amount
+            " output="false" append="true" />
+
+          <do_if value="$importance le 0 or $rating le 0">
+            <continue />
+          </do_if>
+
+          <do_if value="$best == null or $rating gt $best.$rating">
+            <set_value name="$best" exact="table[
+              $ware = $ware,
+              $amount = $amount,
+              $importance = $importance,
+              $rating = $rating,
+            ]" />
           </do_if>
         </do_for_each>
 
-        <do_if value="$bestWare != null">
-          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  PickMiningWare: picked ' + $bestWare + ' (ratio=' + '%.2s'.[$bestRatio] + ')'" append="true" />
-        </do_if>
-
-        <return value="$bestWare" />
+        <return value="$best" />
       </actions>
     </library>
 
@@ -1166,176 +1201,99 @@
       <params>
         <param name="ship" />
         <param name="cargo" comment="$ship.cargo.list snapshot at scheduler entry" />
-        <param name="order" comment="the WarehouseFleet order; needed for supplyTargets and minCargoUsage" />
         <param name="warehouse" comment="$sourceStation" />
-        <param name="deliveries" comment="global delivery reservation table" />
-        <param name="miningOps" comment="global mining-ops table; this lib removes this ship's entries once cargo is handled" />
+        <param name="deliveries" comment="global delivery reservation ledger; this lib turns this ship's pending mining reservations into real deliveries (or releases them)" />
       </params>
       <actions>
-        <create_list name="$remaining" />
-        <append_list_elements name="$remaining" other="$cargo" />
-        <set_value name="$deliveryScheduled" exact="false" />
-
-        <!-- Step 1: try supply-target delivery for each ware (trade orders ship -> supplyTarget). -->
+        <!-- Sell leftover cargo to the home warehouse; the next scheduling round decides where it goes -->
+        <create_list name="$unplaced" />
         <do_for_each in="$cargo" name="$ware">
-          <set_value name="$handled" exact="false" />
-          <set_value name="$amount" exact="$ship.cargo.{$ware}.count" />
-          <do_if value="$amount le 0">
-            <remove_from_list name="$remaining" exact="$ware" />
-            <continue />
-          </do_if>
-
-          <!-- Threshold for the supply-target room check below: volume (m3) of free room required
-               at a supply target = minCargoUsage% of the ship's same-transport cargo capacity.
-               Depends on $ware only, so hoisted out of the per-station loop. -->
-          <set_value name="$shipCapForWare" exact="
-            if $ware.waretransport == waretransport.solid then $ship.cargo.capacity.solid
-            else if $ware.waretransport == waretransport.liquid then $ship.cargo.capacity.liquid
-            else if $ware.waretransport == waretransport.condensate then $ship.cargo.capacity.condensate
-            else $ship.cargo.capacity.container" />
-          <set_value name="$minRoomVolume" exact="$shipCapForWare * $order.$minCargoUsage / 100" />
-
-          <do_for_each in="$order.$supplyTargets" name="$supplyStation">
-            <do_if value="not $supplyStation.exists or not $supplyStation.isclass.container or $supplyStation.idcode == $warehouse.idcode">
-              <continue />
-            </do_if>
-            <do_if value="$ship.iscapitalship and not $ship.units.{unitcategory.transport}.count and not $supplyStation.units.{unitcategory.transport}.count">
-              <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
-                text="'    DeliverMined: skip supply target ' + $supplyStation.knownname + ' (' + $supplyStation.idcode + ') - no cargo drones on capital ship or target'" append="true" />
-              <continue />
-            </do_if>
-            <find_buy_offer buyer="$supplyStation" wares="[$ware]" result="$stOffers" tradepartner="$ship" multiple="true" usereservations="true" excludeempty="false" />
-            <do_if value="$stOffers.count == 0">
-              <continue />
-            </do_if>
-            <set_value name="$stCargo" exact="$supplyStation.cargo.{$ware}.count" />
-            <set_value name="$stTarget" exact="$supplyStation.cargo.{$ware}.target" />
-            <set_value name="$stRoom" exact="[$stTarget - $stCargo, 0].max" />
-            <do_if value="$stRoom le 0">
-              <continue />
-            </do_if>
-
-            <!-- Skip supply targets that can only absorb a sliver compared to ship capacity. -->
-            <do_if value="($stRoom * $ware.volume) lt $minRoomVolume">
-              <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
-                text="'    DeliverMined: skip supply target ' + $supplyStation.idcode + ' for ' + $ware + ' - room ' + $stRoom + ' units (' + ($stRoom * $ware.volume) + ' m3) &lt; minCargoUsage ' + $order.$minCargoUsage + '% of shipCap ' + $shipCapForWare + ' m3'" append="true" />
-              <continue />
-            </do_if>
-
-            <set_value name="$xferAmount" exact="[$amount, $stRoom, $stOffers.{1}.desiredamount].min" />
-            <do_if value="$xferAmount le 0">
-              <continue />
-            </do_if>
-
-            <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
-              text="'  DeliverMined: route ' + $xferAmount + ' ' + $ware + ' to supply target ' + $supplyStation.knownname + ' (' + $supplyStation.idcode + ') - supply target has buy offer and room (' + $stRoom + ' free)'" append="true" />
-            <create_trade_order name="$deliveryOrder" object="$ship" tradeoffer="$stOffers.{1}" amount="$xferAmount" />
-            <set_value name="$delivery" exact="table[
-              $shipID = $ship.idcode,
-              $timeScheduled = player.age,
-              $timeFinished = null,
-              $wareID = $ware.id,
-              $amount = $xferAmount,
-              $providerID = $ship.idcode,
-              $receiverID = $supplyStation.idcode,
-              $providerOrder = null,
-              $receiverOrder = $deliveryOrder,
-            ]" />
-            <append_to_list name="$deliveries" exact="$delivery" />
-            <signal_cue_instantly cue="UpdateDeliveryOnOrderCompletion" param="table[$ship = $ship, $delivery = $delivery, $order = $delivery.$receiverOrder]" />
-            <set_value name="$handled" exact="true" />
-            <set_value name="$deliveryScheduled" exact="true" />
-            <break />
-          </do_for_each>
-
-          <do_if value="$handled">
-            <remove_from_list name="$remaining" exact="$ware" />
-          </do_if>
-        </do_for_each>
-
-        <!-- Step 2: for wares still unhandled, try the home warehouse via a proper trade order. -->
-        <create_list name="$stillRemaining" />
-        <do_for_each in="$remaining" name="$ware">
           <set_value name="$amount" exact="$ship.cargo.{$ware}.count" />
           <do_if value="$amount le 0">
             <continue />
           </do_if>
 
+          <!-- The ship is capital (requires transport drones), but no transport drones are available -->
           <do_if value="$ship.iscapitalship and not $ship.units.{unitcategory.transport}.count and not $warehouse.units.{unitcategory.transport}.count">
             <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
               text="'  DeliverMined: skip home warehouse ' + $warehouse.knownname + ' (' + $warehouse.idcode + ') for ' + $ware + ' - no cargo drones on capital ship or warehouse'" append="true" />
-            <append_to_list name="$stillRemaining" exact="$ware" />
+            <append_to_list name="$unplaced" exact="$ware" />
             <continue />
           </do_if>
           <find_buy_offer buyer="$warehouse" wares="[$ware]" result="$whOffers" tradepartner="$ship" multiple="true" usereservations="true" excludeempty="false" />
+          <!-- Warehouse has no offers for this ware -->
           <do_if value="$whOffers.count == 0">
-            <append_to_list name="$stillRemaining" exact="$ware" />
+            <append_to_list name="$unplaced" exact="$ware" />
             <continue />
           </do_if>
           <set_value name="$whCargo" exact="$warehouse.cargo.{$ware}.count" />
           <set_value name="$whTarget" exact="$warehouse.cargo.{$ware}.target" />
           <set_value name="$whRoom" exact="[$whTarget - $whCargo, 0].max" />
+          <!-- Warehouse has no room for this ware -->
           <do_if value="$whRoom le 0">
-            <append_to_list name="$stillRemaining" exact="$ware" />
+            <append_to_list name="$unplaced" exact="$ware" />
             <continue />
           </do_if>
 
-          <set_value name="$xferAmount" exact="[$amount, $whRoom, $whOffers.{1}.desiredamount].min" />
-          <do_if value="$xferAmount le 0">
-            <append_to_list name="$stillRemaining" exact="$ware" />
+          <!-- True amount of cargo that can be sold to the warehouse -->
+          <set_value name="$sellAmount" exact="[$amount, $whRoom, $whOffers.{1}.desiredamount].min" />
+          <do_if value="$sellAmount le 0">
+            <append_to_list name="$unplaced" exact="$ware" />
             <continue />
           </do_if>
 
           <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
-            text="'  DeliverMined: route ' + $xferAmount + ' ' + $ware + ' to home warehouse ' + $warehouse.knownname + ' (' + $warehouse.idcode + ') - no supply target took it, home has buy offer with ' + $whRoom + ' free'" append="true" />
-          <create_trade_order name="$deliveryOrder" object="$ship" tradeoffer="$whOffers.{1}" amount="$xferAmount" />
-          <set_value name="$delivery" exact="table[
-            $shipID = $ship.idcode,
-            $timeScheduled = player.age,
-            $timeFinished = null,
-            $wareID = $ware.id,
-            $amount = $xferAmount,
-            $providerID = $ship.idcode,
-            $receiverID = $warehouse.idcode,
-            $providerOrder = null,
-            $receiverOrder = $deliveryOrder,
-          ]" />
-          <append_to_list name="$deliveries" exact="$delivery" />
+            text="'  DeliverMined: route ' + $sellAmount + ' ' + $ware + ' to home warehouse ' + $warehouse.knownname + ' (' + $warehouse.idcode + '), ' + $whRoom + ' free'" append="true" />
+          <create_trade_order name="$deliveryOrder" object="$ship" tradeoffer="$whOffers.{1}" amount="$sellAmount" />
+
+          <!-- Reuse the pending mining reservation for this ware if there is one; otherwise
+               (leftover non-mined cargo) create a fresh delivery record -->
+          <set_value name="$delivery" exact="null" />
+          <do_for_each in="$deliveries" name="$existing">
+            <do_if value="@$existing.$isMiningOp and $existing.$shipID == $ship.idcode and $existing.$wareID == $ware.id and $existing.$receiverOrder == null and $existing.$timeFinished == null">
+              <set_value name="$delivery" exact="$existing" />
+              <break />
+            </do_if>
+          </do_for_each>
+          <!-- Found an existing delivery entry -->
+          <do_if value="$delivery != null">
+            <set_value name="$delivery.$amount" exact="$sellAmount" />
+            <set_value name="$delivery.$receiverOrder" exact="$deliveryOrder" />
+          </do_if>
+          <!-- Did not found an existing delivery entry - it's some leftover cargo, create the delivery entry -->
+          <do_else>
+            <set_value name="$delivery" exact="table[
+              $shipID = $ship.idcode,
+              $timeScheduled = player.age,
+              $timeFinished = null,
+              $wareID = $ware.id,
+              $amount = $sellAmount,
+              $providerID = $ship.idcode,
+              $receiverID = $warehouse.idcode,
+              $providerOrder = null,
+              $receiverOrder = $deliveryOrder,
+            ]" />
+            <append_to_list name="$deliveries" exact="$delivery" />
+          </do_else>
           <signal_cue_instantly cue="UpdateDeliveryOnOrderCompletion" param="table[$ship = $ship, $delivery = $delivery, $order = $delivery.$receiverOrder]" />
-          <set_value name="$deliveryScheduled" exact="true" />
         </do_for_each>
 
-        <!-- Step 3: final fallback to the configured $failedOrderHandling for any leftover wares. -->
-        <do_if value="$stillRemaining.count gt 0">
+        <!-- Anything the warehouse cannot take goes to the configured EmptyCargoRoutine -->
+        <do_if value="$unplaced.count gt 0">
           <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
-            text="'  DeliverMined: ' + $stillRemaining.count + ' wares unplaced, falling back to EmptyCargoRoutine (mode=' + global.$WarehouseFleets.$failedOrderHandling + ') - no supply target nor home warehouse had a buy offer / room'" append="true" />
+            text="'  DeliverMined: ' + $unplaced.count + ' wares unplaced, falling back to EmptyCargoRoutine (mode=' + global.$WarehouseFleets.$failedOrderHandling + ')'" append="true" />
           <run_actions ref="EmptyCargoRoutine">
             <param name="ship" value="$ship" />
-            <param name="cargo" value="$stillRemaining" />
+            <param name="cargo" value="$unplaced" />
             <param name="warehouse" value="$warehouse" />
           </run_actions>
         </do_if>
 
-        <!-- After a delivery is queued, send the ship home. The WarehouseFleet outer loop can still
-             preempt this with a real push/pull trade mid-flight; if nothing comes up, the ship
-             lands at the warehouse and the mining fallback (if any) re-fires from the correct
-             anchor instead of starting another mine cycle from wherever the delivery target
-             happened to be. -->
-        <do_if value="$deliveryScheduled and $warehouse.exists">
-          <create_order id="'ReturnToWarehouse'" object="$ship">
-            <param name="destination" value="$warehouse" />
-          </create_order>
-        </do_if>
-
-        <!-- Clear any miningOps entries belonging to this ship for the now-handled cargo. -->
-        <set_value name="$opsToRemove" exact="[]" />
-        <do_for_each in="$miningOps" name="$op">
-          <do_if value="$op.$shipID == $ship.idcode">
-            <append_to_list name="$opsToRemove" exact="$op" />
+        <!-- Release this ship's mining reservations that did not become a delivery (unplaced or vanished cargo) -->
+        <do_for_each in="$deliveries" name="$existing">
+          <do_if value="@$existing.$isMiningOp and $existing.$shipID == $ship.idcode and $existing.$receiverOrder == null and $existing.$timeFinished == null">
+            <set_value name="$existing.$timeFinished" exact="player.age" />
           </do_if>
-        </do_for_each>
-        <do_for_each in="$opsToRemove" name="$op">
-          <remove_from_list name="$miningOps" exact="$op" />
         </do_for_each>
       </actions>
     </library>

--- a/md/warehousefleets.xml
+++ b/md/warehousefleets.xml
@@ -11,7 +11,7 @@
       </actions>
     </cue>
 
-    <cue name="Config" version="7">
+    <cue name="Config" version="8">
       <conditions>
         <check_any>
           <event_cue_signalled cue="md.Setup.GameStart" />
@@ -30,6 +30,7 @@
         <set_value name="global.$WarehouseFleets.$waitInDockL" exact="false" />
         <set_value name="global.$WarehouseFleets.$minCargoUsage" exact="50" />
         <set_value name="global.$WarehouseFleets.$tradeGatePenalty" exact="20" />
+        <set_value name="global.$WarehouseFleets.$miningFallbackIdleSeconds" exact="60" />
       </actions>
 
       <patch sinceversion="6">
@@ -77,6 +78,12 @@
       <patch sinceversion="7">
         <set_value name="global.$WarehouseFleets.$minCargoUsage" exact="[global.$WarehouseFleets.$minCargoUsage, 90].min" comment="reduced max value from 100 to 90" />
       </patch>
+
+      <patch sinceversion="8">
+        <do_if value="@global.$WarehouseFleets.$miningFallbackIdleSeconds == null">
+          <set_value name="global.$WarehouseFleets.$miningFallbackIdleSeconds" exact="60" />
+        </do_if>
+      </patch>
     </cue>
 
     <!-- Main Cue -->
@@ -89,9 +96,16 @@
         <check_value value="true" />
       </conditions>
       <actions>
-        <set_value name="$version" exact="15" />
+        <set_value name="$version" exact="16" />
         <debug_to_file chance="100" name="'config'" directory="'WarehouseFleets'" text="'Initialize Warehouse Fleets Mod, Version = ' + $version" output="false" append="true" />
         <set_value name="$deliveries" exact="[]" />
+        <!-- Idle-mining bookkeeping. $miningOps holds in-flight mining dispatches so the scheduler
+             can reserve warehouse space against ships that are out mining right now. $idleSince is
+             a per-ship clock tracking how long the scheduler has seen "no trade found", so mining
+             is not dispatched the instant a trade window briefly closes. Cleaned up by the
+             GarbageCollector cue. -->
+        <set_value name="$miningOps" exact="[]" />
+        <set_value name="$idleSince" exact="table[]" />
         <signal_cue cue="ShipInitializer" check="false" comment="check=false, da es den Cue erst nach den actions gibt" />
       </actions>
       <cues>
@@ -99,7 +113,7 @@
         <!-- Prüft auf Versions-Updates und resettet ggf. den Main Cue -->
         <cue name="ModVersionWatcher" instantiate="true" checkinterval="1">
           <conditions>
-            <check_value value="parent.$version == null or parent.$version lt 15" />
+            <check_value value="parent.$version == null or parent.$version lt 16" />
           </conditions>
           <actions>
             <debug_to_file chance="100" name="'config'" directory="'WarehouseFleets'" text="'Resetting WarehouseFleets Mod (outdated version detected: '+parent.$version+')'" output="false" append="true" />
@@ -129,10 +143,14 @@
           <actions>
             <set_value name="$ship" exact="event.param3" />
             <set_value name="$deliveries" exact="parent.$deliveries" />
+            <set_value name="$miningOps" exact="parent.$miningOps" />
+            <set_value name="$idleSince" exact="parent.$idleSince" />
             <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'" text="'Schedule request received for ship ' + $ship.idcode" output="false" append="true" />
             <run_actions ref="WarehouseFleetScheduler">
               <param name="ship" value="$ship" />
               <param name="deliveries" value="$deliveries" />
+              <param name="miningOps" value="$miningOps" />
+              <param name="idleSince" value="$idleSince" />
             </run_actions>
           </actions>
         </cue>
@@ -148,6 +166,8 @@
           <actions>
             <set_value name="$ship" exact="if event.name == 'event_player_built_ship' then event.param else event.param3" />
             <set_value name="$deliveries" exact="parent.$deliveries" />
+            <set_value name="$miningOps" exact="parent.$miningOps" />
+            <set_value name="$idleSince" exact="parent.$idleSince" />
             <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'" text="'Registered ship: ' + $ship.idcode" output="false" append="true" />
           </actions>
           <cues>
@@ -181,6 +201,8 @@
                     <run_actions ref="WarehouseFleetScheduler">
                       <param name="ship" value="$ship" />
                       <param name="deliveries" value="$deliveries" />
+                      <param name="miningOps" value="$miningOps" />
+                      <param name="idleSince" value="$idleSince" />
                     </run_actions>
                   </actions>
                 </cue>
@@ -258,6 +280,39 @@
             <do_for_each in="$deliveries" name="$delivery">
               <debug_to_file chance="100" name="'garbage-collector'" directory="'WarehouseFleets'" text="$delivery" output="false" append="true" />
             </do_for_each>
+
+            <!-- Idle-mining bookkeeping cleanup.
+                 - Drop $miningOps entries older than 35min (analogous to the delivery assumption
+                   above: a mining trip is assumed to be done after 30min, 35 is a safe buffer).
+                   Normal cleanup happens in DeliverMinedCargoOrFallback when the cargo arrives;
+                   this is the safety net for ships that died mid-mining or had their default
+                   behaviour changed. -->
+            <set_value name="$miningOps" exact="parent.$miningOps" />
+            <set_value name="$opsToRemove" exact="[]" />
+            <do_for_each in="$miningOps" name="$op">
+              <do_if value="$op.$startedAt lt (player.age - 2100)" comment="2100s = 35min">
+                <append_to_list name="$opsToRemove" exact="$op" />
+              </do_if>
+            </do_for_each>
+            <do_for_each in="$opsToRemove" name="$op">
+              <remove_from_list name="$miningOps" exact="$op" />
+            </do_for_each>
+            <debug_to_file chance="100" name="'garbage-collector'" directory="'WarehouseFleets'" text="$miningOps.count + ' MiningOps:'" output="false" append="true" />
+            <do_for_each in="$miningOps" name="$op">
+              <debug_to_file chance="100" name="'garbage-collector'" directory="'WarehouseFleets'" text="$op" output="false" append="true" />
+            </do_for_each>
+
+            <!-- Idle clock cleanup: drop entries whose ship is gone. -->
+            <set_value name="$idleSince" exact="parent.$idleSince" />
+            <set_value name="$idleKeysToRemove" exact="[]" />
+            <do_for_each in="$idleSince.keys.list" name="$idleShip">
+              <do_if value="not $idleShip.exists">
+                <append_to_list name="$idleKeysToRemove" exact="$idleShip" />
+              </do_if>
+            </do_for_each>
+            <do_for_each in="$idleKeysToRemove" name="$idleShip">
+              <remove_value name="$idleSince.{$idleShip}" />
+            </do_for_each>
           </actions>
         </cue>
 
@@ -270,6 +325,8 @@
       <params>
         <param name="ship" />
         <param name="deliveries" />
+        <param name="miningOps" />
+        <param name="idleSince" />
       </params>
       <actions>
         <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'==============================='" output="false" append="false" />
@@ -289,14 +346,32 @@
           <transfer_money from="$sourceStation" to="faction.player" amount="$moneyToTransfer" />
         </do_if>
 
-        <!-- Schiff leer machen, falls noch Ladung vorhanden -->
+        <!-- Schiff leer machen, falls noch Ladung vorhanden.
+             Mining-capable ships (solid/liquid cargo) route through DeliverMinedCargoOrFallback
+             instead, so mined cargo gets properly delivered: supply targets first, then the home
+             warehouse via a real trade order, and only then the configured $failedOrderHandling
+             (refund/teleport/...). Container-only ships keep the original EmptyCargoRoutine path
+             unchanged. -->
         <set_value name="$cargo" exact="$ship.cargo.list" />
         <do_if value="$cargo.count gt 0">
-          <run_actions ref="EmptyCargoRoutine">
-            <param name="ship" value="$ship" />
-            <param name="cargo" value="$cargo" />
-            <param name="warehouse" value="$sourceStation" />
-          </run_actions>
+          <do_if value="$ship.cargo.capacity.solid gt 0 or $ship.cargo.capacity.liquid gt 0">
+            <run_actions ref="DeliverMinedCargoOrFallback">
+              <param name="ship" value="$ship" />
+              <param name="cargo" value="$cargo" />
+              <param name="order" value="$order" />
+              <param name="warehouse" value="$sourceStation" />
+              <param name="deliveries" value="$deliveries" />
+              <param name="miningOps" value="$miningOps" />
+            </run_actions>
+            <return comment="delivery orders (if any) were created; do not also schedule trades this cycle" />
+          </do_if>
+          <do_else>
+            <run_actions ref="EmptyCargoRoutine">
+              <param name="ship" value="$ship" />
+              <param name="cargo" value="$cargo" />
+              <param name="warehouse" value="$sourceStation" />
+            </run_actions>
+          </do_else>
         </do_if>
 
         <!-- Target Stations ermitteln (als Targets können auch Sektoren angegeben werden) -->
@@ -381,7 +456,21 @@
 
         <do_if value="$bestPushTrip == null and $bestPullTrip == null">
           <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'No trade found that meets minimum cargo usage requirement'" output="false" append="true" />
+          <run_actions ref="TryMiningFallback">
+            <param name="ship" value="$ship" />
+            <param name="order" value="$order" />
+            <param name="sourceStation" value="$sourceStation" />
+            <param name="miningOps" value="$miningOps" />
+            <param name="idleSince" value="$idleSince" />
+          </run_actions>
           <return />
+        </do_if>
+
+        <!-- A trade WAS found - the ship gets real work this cycle. Clear the idle clock so a
+             future "no trade" doesn't immediately count the current idleness against the
+             mining-fallback threshold. -->
+        <do_if value="$idleSince.{$ship}?">
+          <remove_value name="$idleSince.{$ship}" />
         </do_if>
 
         <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'Best Push Trip: ' + $bestPushTrip" output="false" append="true" />
@@ -877,6 +966,377 @@
             <write_to_logbook category="upkeep" entity="$warehouse" object="$ship" interaction="showonmap" title="'WarehouseFleet: Cargo Empty Routine ('+$warehouse.idcode+')'" text="$recoveryText" />
           </do_all>
         </do_elseif>
+      </actions>
+    </library>
+
+    <!-- ============================================================================================
+         Idle-mining fallback libraries.
+         Used when the scheduler finds no eligible trade for a mining-capable ship and the per-ship
+         idle timer has expired. Picks an under-stocked solid/liquid ware the home warehouse buys,
+         reserves the projected delivery against in-flight mining ops, and dispatches the one-shot
+         WarehouseFleetMine order (aiscripts/order.warehousefleet.mining.xml). After mining ends,
+         the WarehouseFleet attention cycle resumes, the scheduler sees cargo aboard, and
+         DeliverMinedCargoOrFallback routes it into a useful destination.
+         ============================================================================================ -->
+
+    <library name="TryMiningFallback" purpose="run_actions" namespace="this">
+      <params>
+        <param name="ship" />
+        <param name="order" />
+        <param name="sourceStation" />
+        <param name="miningOps" />
+        <param name="idleSince" />
+      </params>
+      <actions>
+        <!-- Per-fleet opt-in. -->
+        <do_if value="not $order.$miningFallback">
+          <return />
+        </do_if>
+
+        <!-- Ship must be mining-capable: solid or liquid cargo capacity. -->
+        <do_if value="$ship.cargo.capacity.solid le 0 and $ship.cargo.capacity.liquid le 0">
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  MiningFallback: ship has no solid/liquid cargo (container-only); skip'" append="true" />
+          <return />
+        </do_if>
+
+        <!-- "Idle" really means idle. If the ship has any active order (e.g. mid-trade, or just
+             pre-planned via ScheduleFollowUpTripWhenDocking while still selling), treat it as
+             busy: clear the idle clock and don't dispatch mining. Otherwise the idle clock ticks
+             forward while the ship is executing a delivery and mining fires right after a trade
+             completes. -->
+        <do_if value="$ship.orders.count gt 0">
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  MiningFallback: ship has ' + $ship.orders.count + ' active order(s); not idle, clearing timer'" append="true" />
+          <do_if value="$idleSince.{$ship}?">
+            <remove_value name="$idleSince.{$ship}" />
+          </do_if>
+          <return />
+        </do_if>
+
+        <!-- Idle clock: start it on first observation, then check against the threshold on
+             subsequent scheduler runs. -->
+        <do_if value="not $idleSince.{$ship}?">
+          <set_value name="$idleSince.{$ship}" exact="player.age" />
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  MiningFallback: starting idle clock at age=' + player.age" append="true" />
+          <return />
+        </do_if>
+
+        <set_value name="$idleFor" exact="player.age - $idleSince.{$ship}" />
+        <do_if value="$idleFor lt global.$WarehouseFleets.$miningFallbackIdleSeconds">
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  MiningFallback: idle for ' + $idleFor + 's, threshold=' + global.$WarehouseFleets.$miningFallbackIdleSeconds + 's; still warming up'" append="true" />
+          <return />
+        </do_if>
+
+        <!-- Pick the most under-stocked mineable ware the warehouse buys (and has room for, after
+             accounting for in-flight reservations). -->
+        <run_actions ref="PickMiningWare" result="$pickedWare">
+          <param name="ship" value="$ship" />
+          <param name="sourceStation" value="$sourceStation" />
+          <param name="miningOps" value="$miningOps" />
+        </run_actions>
+
+        <do_if value="$pickedWare == null">
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  MiningFallback: no suitable ware to mine; remaining idle'" append="true" />
+          <return />
+        </do_if>
+
+        <!-- Record the op so concurrent scheduler runs reserve room against this ship's projected arrival. -->
+        <set_value name="$shipMaxUnits" exact="
+          if $pickedWare.waretransport == waretransport.solid then ($ship.cargo.capacity.solid / $pickedWare.volume)i
+          else if $pickedWare.waretransport == waretransport.liquid then ($ship.cargo.capacity.liquid / $pickedWare.volume)i
+          else 0
+        " />
+        <append_to_list name="$miningOps" exact="table[
+          $shipID = $ship.idcode,
+          $warehouseID = $sourceStation.idcode,
+          $wareID = $pickedWare.id,
+          $ware = $pickedWare,
+          $expectedAmount = $shipMaxUnits,
+          $startedAt = player.age,
+        ]" />
+
+        <!-- Reset idle clock - the ship is getting something to do now. -->
+        <remove_value name="$idleSince.{$ship}" />
+
+        <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+          text="'  MiningFallback: dispatching WarehouseFleetMine for ' + $pickedWare + ' (max ~' + $shipMaxUnits + ' units), anchor=' + $sourceStation.sector.knownname" append="true" />
+        <debug_to_file chance="100" name="'scheduler'" directory="'WarehouseFleets'"
+          text="'MiningFallback dispatch: ship=' + $ship.idcode + ' ware=' + $pickedWare + ' reserved=' + $shipMaxUnits + ' anchor=' + $sourceStation.sector.knownname + ' maxGateDist=' + $order.$miningMaxGateDistance" append="true" />
+
+        <!-- One-shot mining order (aiscripts/order.warehousefleet.mining.xml): dispatches a single
+             MiningCollect sub-order, waits for it to finish (cargo full or area depleted), and
+             ends. No selling, no looping. Afterwards the ship's default behaviour (WarehouseFleet)
+             resumes, the scheduler sees the cargo and routes it via DeliverMinedCargoOrFallback. -->
+        <create_order id="'WarehouseFleetMine'" object="$ship">
+          <param name="ware" value="$pickedWare" />
+          <param name="anchorSector" value="$sourceStation.sector" />
+          <param name="maxGateDistance" value="$order.$miningMaxGateDistance" />
+        </create_order>
+      </actions>
+    </library>
+
+    <library name="PickMiningWare" purpose="run_actions" namespace="this">
+      <params>
+        <param name="ship" />
+        <param name="sourceStation" />
+        <param name="miningOps" />
+      </params>
+      <actions>
+        <!-- Candidate ware list based on the ship's cargo capacity. Nividium is deliberately
+             excluded (warehouses rarely buy it; it is a sell-for-cash ware, not a supply ware). -->
+        <create_list name="$candidates" />
+        <do_if value="$ship.cargo.capacity.solid gt 0">
+          <append_to_list name="$candidates" exact="ware.ore" />
+          <append_to_list name="$candidates" exact="ware.silicon" />
+          <append_to_list name="$candidates" exact="ware.ice" />
+        </do_if>
+        <do_if value="$ship.cargo.capacity.liquid gt 0">
+          <append_to_list name="$candidates" exact="ware.hydrogen" />
+          <append_to_list name="$candidates" exact="ware.methane" />
+          <append_to_list name="$candidates" exact="ware.helium" />
+        </do_if>
+
+        <do_if value="$candidates.count == 0">
+          <return value="null" />
+        </do_if>
+
+        <!-- For each candidate compute: buy offer at home, current cargo, target capacity,
+             in-flight reservations from miningOps, projected post-arrival fullness. Skip
+             candidates the warehouse won't have room for; among the rest pick the most
+             under-stocked one (lowest cargo/target ratio). -->
+        <set_value name="$bestWare" exact="null" />
+        <set_value name="$bestRatio" exact="2.0" comment="anything &gt; 1.0 means 'no candidate picked yet'" />
+
+        <do_for_each in="$candidates" name="$ware">
+          <!-- Does the home warehouse buy this ware? -->
+          <find_buy_offer buyer="$sourceStation" wares="[$ware]" result="$wareBuyOffers" tradepartner="$ship" multiple="true" usereservations="false" excludeempty="false" />
+          <do_if value="$wareBuyOffers.count == 0">
+            <continue />
+          </do_if>
+
+          <!-- Storage state. -->
+          <set_value name="$wareCargo" exact="$sourceStation.cargo.{$ware}.count" />
+          <set_value name="$wareTarget" exact="$sourceStation.cargo.{$ware}.target" />
+          <do_if value="$wareTarget le 0">
+            <continue comment="warehouse has no storage allocation for this ware" />
+          </do_if>
+
+          <!-- Sum of in-flight reservations (other ships' projected arrivals for this ware). -->
+          <set_value name="$reserved" exact="0" />
+          <do_for_each in="$miningOps" name="$op">
+            <do_if value="$op.$warehouseID == $sourceStation.idcode and $op.$wareID == $ware.id">
+              <set_value name="$reserved" operation="add" exact="$op.$expectedAmount" />
+            </do_if>
+          </do_for_each>
+
+          <!-- This ship's own max contribution if it mined this ware. -->
+          <set_value name="$shipCapacityForWare" exact="
+            if $ware.waretransport == waretransport.solid then $ship.cargo.capacity.solid
+            else if $ware.waretransport == waretransport.liquid then $ship.cargo.capacity.liquid
+            else 0
+          " />
+          <set_value name="$shipMaxUnits" exact="($shipCapacityForWare / $ware.volume)i" />
+
+          <!-- Room exhaustion check. -->
+          <set_value name="$projected" exact="$wareCargo + $reserved + $shipMaxUnits" />
+          <do_if value="$projected ge $wareTarget">
+            <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+              text="'  PickMiningWare: skip ' + $ware + ' (projected=' + $projected + ' &gt;= target=' + $wareTarget + '; reserved=' + $reserved + ')'" append="true" />
+            <continue />
+          </do_if>
+
+          <set_value name="$ratio" exact="($wareCargo)f / $wareTarget" />
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+            text="'  PickMiningWare: candidate ' + $ware + ' ratio=' + '%.2s'.[$ratio] + ' (cargo=' + $wareCargo + '/' + $wareTarget + ' reserved=' + $reserved + ' shipMax=' + $shipMaxUnits + ')'" append="true" />
+
+          <do_if value="$ratio lt $bestRatio">
+            <set_value name="$bestWare" exact="$ware" />
+            <set_value name="$bestRatio" exact="$ratio" />
+          </do_if>
+        </do_for_each>
+
+        <do_if value="$bestWare != null">
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'" text="'  PickMiningWare: picked ' + $bestWare + ' (ratio=' + '%.2s'.[$bestRatio] + ')'" append="true" />
+        </do_if>
+
+        <return value="$bestWare" />
+      </actions>
+    </library>
+
+    <library name="DeliverMinedCargoOrFallback" purpose="run_actions" namespace="this">
+      <params>
+        <param name="ship" />
+        <param name="cargo" comment="$ship.cargo.list snapshot at scheduler entry" />
+        <param name="order" comment="the WarehouseFleet order; needed for supplyTargets and minCargoUsage" />
+        <param name="warehouse" comment="$sourceStation" />
+        <param name="deliveries" comment="global delivery reservation table" />
+        <param name="miningOps" comment="global mining-ops table; this lib removes this ship's entries once cargo is handled" />
+      </params>
+      <actions>
+        <create_list name="$remaining" />
+        <append_list_elements name="$remaining" other="$cargo" />
+        <set_value name="$deliveryScheduled" exact="false" />
+
+        <!-- Step 1: try supply-target delivery for each ware (trade orders ship -> supplyTarget). -->
+        <do_for_each in="$cargo" name="$ware">
+          <set_value name="$handled" exact="false" />
+          <set_value name="$amount" exact="$ship.cargo.{$ware}.count" />
+          <do_if value="$amount le 0">
+            <remove_from_list name="$remaining" exact="$ware" />
+            <continue />
+          </do_if>
+
+          <!-- Threshold for the supply-target room check below: volume (m3) of free room required
+               at a supply target = minCargoUsage% of the ship's same-transport cargo capacity.
+               Depends on $ware only, so hoisted out of the per-station loop. -->
+          <set_value name="$shipCapForWare" exact="
+            if $ware.waretransport == waretransport.solid then $ship.cargo.capacity.solid
+            else if $ware.waretransport == waretransport.liquid then $ship.cargo.capacity.liquid
+            else if $ware.waretransport == waretransport.condensate then $ship.cargo.capacity.condensate
+            else $ship.cargo.capacity.container" />
+          <set_value name="$minRoomVolume" exact="$shipCapForWare * $order.$minCargoUsage / 100" />
+
+          <do_for_each in="$order.$supplyTargets" name="$supplyStation">
+            <do_if value="not $supplyStation.exists or not $supplyStation.isclass.container or $supplyStation.idcode == $warehouse.idcode">
+              <continue />
+            </do_if>
+            <do_if value="$ship.iscapitalship and not $ship.units.{unitcategory.transport}.count and not $supplyStation.units.{unitcategory.transport}.count">
+              <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+                text="'    DeliverMined: skip supply target ' + $supplyStation.knownname + ' (' + $supplyStation.idcode + ') - no cargo drones on capital ship or target'" append="true" />
+              <continue />
+            </do_if>
+            <find_buy_offer buyer="$supplyStation" wares="[$ware]" result="$stOffers" tradepartner="$ship" multiple="true" usereservations="true" excludeempty="false" />
+            <do_if value="$stOffers.count == 0">
+              <continue />
+            </do_if>
+            <set_value name="$stCargo" exact="$supplyStation.cargo.{$ware}.count" />
+            <set_value name="$stTarget" exact="$supplyStation.cargo.{$ware}.target" />
+            <set_value name="$stRoom" exact="[$stTarget - $stCargo, 0].max" />
+            <do_if value="$stRoom le 0">
+              <continue />
+            </do_if>
+
+            <!-- Skip supply targets that can only absorb a sliver compared to ship capacity. -->
+            <do_if value="($stRoom * $ware.volume) lt $minRoomVolume">
+              <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+                text="'    DeliverMined: skip supply target ' + $supplyStation.idcode + ' for ' + $ware + ' - room ' + $stRoom + ' units (' + ($stRoom * $ware.volume) + ' m3) &lt; minCargoUsage ' + $order.$minCargoUsage + '% of shipCap ' + $shipCapForWare + ' m3'" append="true" />
+              <continue />
+            </do_if>
+
+            <set_value name="$xferAmount" exact="[$amount, $stRoom, $stOffers.{1}.desiredamount].min" />
+            <do_if value="$xferAmount le 0">
+              <continue />
+            </do_if>
+
+            <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+              text="'  DeliverMined: route ' + $xferAmount + ' ' + $ware + ' to supply target ' + $supplyStation.knownname + ' (' + $supplyStation.idcode + ') - supply target has buy offer and room (' + $stRoom + ' free)'" append="true" />
+            <create_trade_order name="$deliveryOrder" object="$ship" tradeoffer="$stOffers.{1}" amount="$xferAmount" />
+            <set_value name="$delivery" exact="table[
+              $shipID = $ship.idcode,
+              $timeScheduled = player.age,
+              $timeFinished = null,
+              $wareID = $ware.id,
+              $amount = $xferAmount,
+              $providerID = $ship.idcode,
+              $receiverID = $supplyStation.idcode,
+              $providerOrder = null,
+              $receiverOrder = $deliveryOrder,
+            ]" />
+            <append_to_list name="$deliveries" exact="$delivery" />
+            <signal_cue_instantly cue="UpdateDeliveryOnOrderCompletion" param="table[$ship = $ship, $delivery = $delivery, $order = $delivery.$receiverOrder]" />
+            <set_value name="$handled" exact="true" />
+            <set_value name="$deliveryScheduled" exact="true" />
+            <break />
+          </do_for_each>
+
+          <do_if value="$handled">
+            <remove_from_list name="$remaining" exact="$ware" />
+          </do_if>
+        </do_for_each>
+
+        <!-- Step 2: for wares still unhandled, try the home warehouse via a proper trade order. -->
+        <create_list name="$stillRemaining" />
+        <do_for_each in="$remaining" name="$ware">
+          <set_value name="$amount" exact="$ship.cargo.{$ware}.count" />
+          <do_if value="$amount le 0">
+            <continue />
+          </do_if>
+
+          <do_if value="$ship.iscapitalship and not $ship.units.{unitcategory.transport}.count and not $warehouse.units.{unitcategory.transport}.count">
+            <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+              text="'  DeliverMined: skip home warehouse ' + $warehouse.knownname + ' (' + $warehouse.idcode + ') for ' + $ware + ' - no cargo drones on capital ship or warehouse'" append="true" />
+            <append_to_list name="$stillRemaining" exact="$ware" />
+            <continue />
+          </do_if>
+          <find_buy_offer buyer="$warehouse" wares="[$ware]" result="$whOffers" tradepartner="$ship" multiple="true" usereservations="true" excludeempty="false" />
+          <do_if value="$whOffers.count == 0">
+            <append_to_list name="$stillRemaining" exact="$ware" />
+            <continue />
+          </do_if>
+          <set_value name="$whCargo" exact="$warehouse.cargo.{$ware}.count" />
+          <set_value name="$whTarget" exact="$warehouse.cargo.{$ware}.target" />
+          <set_value name="$whRoom" exact="[$whTarget - $whCargo, 0].max" />
+          <do_if value="$whRoom le 0">
+            <append_to_list name="$stillRemaining" exact="$ware" />
+            <continue />
+          </do_if>
+
+          <set_value name="$xferAmount" exact="[$amount, $whRoom, $whOffers.{1}.desiredamount].min" />
+          <do_if value="$xferAmount le 0">
+            <append_to_list name="$stillRemaining" exact="$ware" />
+            <continue />
+          </do_if>
+
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+            text="'  DeliverMined: route ' + $xferAmount + ' ' + $ware + ' to home warehouse ' + $warehouse.knownname + ' (' + $warehouse.idcode + ') - no supply target took it, home has buy offer with ' + $whRoom + ' free'" append="true" />
+          <create_trade_order name="$deliveryOrder" object="$ship" tradeoffer="$whOffers.{1}" amount="$xferAmount" />
+          <set_value name="$delivery" exact="table[
+            $shipID = $ship.idcode,
+            $timeScheduled = player.age,
+            $timeFinished = null,
+            $wareID = $ware.id,
+            $amount = $xferAmount,
+            $providerID = $ship.idcode,
+            $receiverID = $warehouse.idcode,
+            $providerOrder = null,
+            $receiverOrder = $deliveryOrder,
+          ]" />
+          <append_to_list name="$deliveries" exact="$delivery" />
+          <signal_cue_instantly cue="UpdateDeliveryOnOrderCompletion" param="table[$ship = $ship, $delivery = $delivery, $order = $delivery.$receiverOrder]" />
+          <set_value name="$deliveryScheduled" exact="true" />
+        </do_for_each>
+
+        <!-- Step 3: final fallback to the configured $failedOrderHandling for any leftover wares. -->
+        <do_if value="$stillRemaining.count gt 0">
+          <debug_to_file chance="100" name="$ship.idcode" directory="'WarehouseFleets'"
+            text="'  DeliverMined: ' + $stillRemaining.count + ' wares unplaced, falling back to EmptyCargoRoutine (mode=' + global.$WarehouseFleets.$failedOrderHandling + ') - no supply target nor home warehouse had a buy offer / room'" append="true" />
+          <run_actions ref="EmptyCargoRoutine">
+            <param name="ship" value="$ship" />
+            <param name="cargo" value="$stillRemaining" />
+            <param name="warehouse" value="$warehouse" />
+          </run_actions>
+        </do_if>
+
+        <!-- After a delivery is queued, send the ship home. The WarehouseFleet outer loop can still
+             preempt this with a real push/pull trade mid-flight; if nothing comes up, the ship
+             lands at the warehouse and the mining fallback (if any) re-fires from the correct
+             anchor instead of starting another mine cycle from wherever the delivery target
+             happened to be. -->
+        <do_if value="$deliveryScheduled and $warehouse.exists">
+          <create_order id="'ReturnToWarehouse'" object="$ship">
+            <param name="destination" value="$warehouse" />
+          </create_order>
+        </do_if>
+
+        <!-- Clear any miningOps entries belonging to this ship for the now-handled cargo. -->
+        <set_value name="$opsToRemove" exact="[]" />
+        <do_for_each in="$miningOps" name="$op">
+          <do_if value="$op.$shipID == $ship.idcode">
+            <append_to_list name="$opsToRemove" exact="$op" />
+          </do_if>
+        </do_for_each>
+        <do_for_each in="$opsToRemove" name="$op">
+          <remove_from_list name="$miningOps" exact="$op" />
+        </do_for_each>
       </actions>
     </library>
 

--- a/md/warehousefleets_menu.xml
+++ b/md/warehousefleets_menu.xml
@@ -54,6 +54,11 @@
             'Drop: wares are dropped',
         ]" />
 
+        <signal_cue_instantly cue="AddSliderRow" param="table[
+          $id = 'miningFallbackIdleSeconds', $min = 0, $max = 600, $suffix = 's', $default = 60, $text = 'Mining fallback idle time (s)',
+          $mouseOverText = 'How long a mining-capable ship with the Mine When Idle fleet option must stay without any trade job before the scheduler dispatches a one-shot mining trip for the home warehouse'
+        ]" />
+
         <signal_cue_instantly cue="AddEmptyRow" />
         <signal_cue_instantly cue="AddEmptyRow" />
         <signal_cue_instantly cue="AddCenteredTextRow" param="table[$text='Default Fleet Settings (applied when creating new WarehouseFleets)']" />

--- a/md/warehousefleets_menu.xml
+++ b/md/warehousefleets_menu.xml
@@ -54,11 +54,6 @@
             'Drop: wares are dropped',
         ]" />
 
-        <signal_cue_instantly cue="AddSliderRow" param="table[
-          $id = 'miningFallbackIdleSeconds', $min = 0, $max = 600, $suffix = 's', $default = 60, $text = 'Mining fallback idle time (s)',
-          $mouseOverText = 'How long a mining-capable ship with the Mine When Idle fleet option must stay without any trade job before the scheduler dispatches a one-shot mining trip for the home warehouse'
-        ]" />
-
         <signal_cue_instantly cue="AddEmptyRow" />
         <signal_cue_instantly cue="AddEmptyRow" />
         <signal_cue_instantly cue="AddCenteredTextRow" param="table[$text='Default Fleet Settings (applied when creating new WarehouseFleets)']" />
@@ -86,6 +81,10 @@
 
         <signal_cue_instantly cue="AddSliderRow" param="table[$id = 'prioBuild', $min = 0, $max = 10, $suffix = '', $default = 7, $text = 'Prio: Build', $mouseOverText = 'Priority of jobs supplying player-owned build storages']" />
         <signal_cue_instantly cue="AddSyncButtonRow" param="table[$id = 'prioBuild']" />
+        <signal_cue_instantly cue="AddEmptyRow" />
+
+        <signal_cue_instantly cue="AddSliderRow" param="table[$id = 'prioMining', $min = 0, $max = 10, $suffix = '', $default = 4, $text = 'Prio: Mining', $mouseOverText = 'Priority of mining trips for mining-capable ships. Mining attractivity grows as the home warehouse runs low on a mineable ware. 0 disables mining completely.']" />
+        <signal_cue_instantly cue="AddSyncButtonRow" param="table[$id = 'prioMining']" />
         <signal_cue_instantly cue="AddEmptyRow" />
 
         <signal_cue_instantly cue="AddCheckboxRow" param="table[$id = 'waitInDockS', $default = true, $text = 'Dock idle S-sized ships', $mouseOverText = 'S-sized ships should dock at their home warehouse while waiting for new delivery jobs']" />

--- a/readme.md
+++ b/readme.md
@@ -39,8 +39,8 @@ To make this work, every warehouse gets assigned a "WarehouseFleet", composed of
 | Prio: Build | Set to high values to generally favor filling build storages over other tasks. |
 | Min. Cargo Usage (%) | Avoids scheduling inefficient trips. No ship will be scheduled that uses less than the specified cargo space. Setting this value too low can cause performance degradation. Setting the value too high might prevent/delay balancing of low volume wares. Ships supplying build storages may ignore this setting to avoid build jobs getting stuck with only a few materials left. |
 | Trades: Gate Penalty (%) | Reduces the attractivity of trades in other sectors to keep travel distances short. |
-| Mine When Idle | Only relevant for mining ships (solid or liquid cargo). When enabled and the scheduler cannot find any trade for the ship, it dispatches a one-shot mining trip to fill the home warehouse with its most under-stocked mineable ware (ore/silicon/ice for solid, hydrogen/methane/helium for liquid). The warehouse must have a buy offer and free storage allocation for the ware. Off by default. |
-| Mining: Max Gate Distance | How many jump gates away from the home warehouse's sector the idle-mining trip may search for resources. 0 = home sector only. |
+| Prio: Mining | Only relevant for mining ships (solid or liquid cargo). Set to high values to generally favor mining trips over other tasks. Mining attractivity grows as the home warehouse runs low on a minable ware the ship can carry (including modded resources) and falls to zero when it is well stocked. 0 disables mining completely (default). |
+| Mining: Max Gate Distance | How many jump gates away from the home warehouse's sector a mining trip may search for resources. 0 = home sector only. |
 
 ## Global Settings
 
@@ -51,15 +51,17 @@ The global settings can be found in the "Extension Options" via the menu.
 | Player Account Threshold | Configures the minimum amount of money that should be left to the player, since buying missing wares from NPC traders can quickly drain your account. |
 | Auto-transfer money | Regularly transfer money from station accounts to the player, if at least 10% above the operating budget of the station |
 | Cargo emptying routine | Sometimes trades can fail, leaving ships with remaining cargo - this can be resolved in different ways. Check the ingame tooltip for available options. |
-| Mining fallback idle time | How long a mining-capable ship with "Mine When Idle" must stay without any trade job before a mining trip is dispatched. Prevents mining from firing during a brief gap between trades. |
 
-## Idle Mining Fallback
+## Mining
 
-Mining ships used as warehouse freighters (they are the only ships that can transport solid/liquid wares like ore or hydrogen) tend to idle a lot when the network is saturated. With the per-fleet "Mine When Idle" option enabled, such a ship that has had no trade job for a while will fly out, mine the home warehouse's most under-stocked mineable ware, and deliver it back:
+Mining ships used as warehouse freighters (they are the only ships that can transport solid/liquid wares like ore or hydrogen) tend to idle a lot when the network is saturated - while the very wares their warehouse stocks float around them. With "Prio: Mining" above 0, mining trips compete with the other tasks in the same priority system:
 
-- The delivery first tries the fleet's Supply Targets, then the home warehouse, through normal trade orders. Only if neither can take the cargo does the configured cargo emptying routine kick in.
-- Concurrent mining trips reserve warehouse storage against each other, so ten miners will not all fetch the same ware for the same half-empty tank.
-- The mining trip is a single one-shot order (no mine/sell loop); afterwards the ship returns to normal WarehouseFleet behaviour.
+- Mining attractivity is based on the home warehouse's storage level for each mineable ware it buys: zero when well stocked, high when starving. "Prio: Mining" equal to "Prio: Distribute" makes mining roughly as attractive as fetching the same ware from a full neighbor warehouse.
+- Mined cargo is always sold to the home warehouse; the next scheduling round decides where it is actually needed.
+- Mining trips reserve warehouse storage in the same ledger as normal deliveries, so miners and traders cannot overbook the same storage.
+- Vanilla mining collects until the ship is full, so a ware is only mined when the warehouse has room for a full shipload. If your warehouse allocates less storage to a resource than one full cargo bay of your miner, that miner will never mine it.
+- The mining trip is a single one-shot order (no mine/sell loop). A watcher recalls ships whose trip stops making progress (e.g. exhausted resource fields), so miners cannot get locked up indefinitely; they come home with whatever they gathered.
+- A trip that comes back empty (no minable field within the gate distance, or a depleted one) puts that ware on a 15-minute cooldown for the warehouse, so ships are not dispatched into the same dead spot over and over.
 
 ## Warehouses, Trade Wares and Restrictions
 

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ To make this work, every warehouse gets assigned a "WarehouseFleet", composed of
 | Prio: Build | Set to high values to generally favor filling build storages over other tasks. |
 | Min. Cargo Usage (%) | Avoids scheduling inefficient trips. No ship will be scheduled that uses less than the specified cargo space. Setting this value too low can cause performance degradation. Setting the value too high might prevent/delay balancing of low volume wares. Ships supplying build storages may ignore this setting to avoid build jobs getting stuck with only a few materials left. |
 | Trades: Gate Penalty (%) | Reduces the attractivity of trades in other sectors to keep travel distances short. |
+| Mine When Idle | Only relevant for mining ships (solid or liquid cargo). When enabled and the scheduler cannot find any trade for the ship, it dispatches a one-shot mining trip to fill the home warehouse with its most under-stocked mineable ware (ore/silicon/ice for solid, hydrogen/methane/helium for liquid). The warehouse must have a buy offer and free storage allocation for the ware. Off by default. |
+| Mining: Max Gate Distance | How many jump gates away from the home warehouse's sector the idle-mining trip may search for resources. 0 = home sector only. |
 
 ## Global Settings
 
@@ -49,6 +51,15 @@ The global settings can be found in the "Extension Options" via the menu.
 | Player Account Threshold | Configures the minimum amount of money that should be left to the player, since buying missing wares from NPC traders can quickly drain your account. |
 | Auto-transfer money | Regularly transfer money from station accounts to the player, if at least 10% above the operating budget of the station |
 | Cargo emptying routine | Sometimes trades can fail, leaving ships with remaining cargo - this can be resolved in different ways. Check the ingame tooltip for available options. |
+| Mining fallback idle time | How long a mining-capable ship with "Mine When Idle" must stay without any trade job before a mining trip is dispatched. Prevents mining from firing during a brief gap between trades. |
+
+## Idle Mining Fallback
+
+Mining ships used as warehouse freighters (they are the only ships that can transport solid/liquid wares like ore or hydrogen) tend to idle a lot when the network is saturated. With the per-fleet "Mine When Idle" option enabled, such a ship that has had no trade job for a while will fly out, mine the home warehouse's most under-stocked mineable ware, and deliver it back:
+
+- The delivery first tries the fleet's Supply Targets, then the home warehouse, through normal trade orders. Only if neither can take the cargo does the configured cargo emptying routine kick in.
+- Concurrent mining trips reserve warehouse storage against each other, so ten miners will not all fetch the same ware for the same half-empty tank.
+- The mining trip is a single one-shot order (no mine/sell loop); afterwards the ship returns to normal WarehouseFleet behaviour.
 
 ## Warehouses, Trade Wares and Restrictions
 


### PR DESCRIPTION
# PR: Idle-mining fallback for mining ships ("Mine When Idle")

## Motivation

Solid/liquid wares (ore, silicon, ice, hydrogen, methane, helium) can only be transported by mining ships, so warehouse networks that distribute raw resources are necessarily crewed by miners. Those ships idle a lot when the network is saturated — and unlike container traders they can do something genuinely useful while idle: mine the very wares their home warehouse stocks.

This PR adds an opt-in, per-fleet "Mine When Idle" option. When the scheduler repeatedly finds no trade for a mining-capable ship, the ship flies out, mines the home warehouse's most under-stocked mineable ware, and delivers it back through normal trade orders.

## What it does

1. **Trigger**: when `WarehouseFleetScheduler` ends a cycle with "No trade found" for a ship whose fleet has `miningFallback` enabled and which has solid or liquid cargo capacity, a per-ship idle clock starts. Only after the ship has stayed jobless for a configurable time (global setting, default 60s) is a mining trip dispatched. The clock is cleared whenever the ship gets real work or has any active order, so mining never fires in the middle of a delivery.
2. **Ware selection** (`PickMiningWare`): among ore/silicon/ice (solid) and hydrogen/methane/helium (liquid — nividium is deliberately excluded), pick the ware with the lowest `cargo/target` ratio at the home warehouse, but only if the warehouse has a buy offer for it, a storage allocation, and projected room left after accounting for **in-flight mining reservations** — concurrent trips register in a shared `$miningOps` table, so multiple miners never all fetch the same ware for the same half-empty tank. Stale reservations (ship died mid-trip, behaviour changed) are aged out by the existing GarbageCollector cue after 35 minutes, mirroring the 30-minute delivery assumption already used there.
3. **Mining trip** (`aiscripts/order.warehousefleet.mining.xml`, new): a one-shot internal order. Vanilla `MiningRoutine` is an infinite mine→sell loop and fights the mod's own delivery flow, so this order instead scores candidate sectors around the home sector by `yieldrating / (1 + gateDistance * 0.4)` (respecting sector blacklists via `lib.find.sectors.inrange`), picks a resource patch with a randomized min-rating floor (spreads ships across patches instead of converging on the single best rock), dispatches a single vanilla `MiningCollect` sub-order, releases the yield reservation, and ends. The ship then falls back to its WarehouseFleet default behaviour.
4. **Delivery** (`DeliverMinedCargoOrFallback`): on the next scheduler cycle the cargo aboard is routed: Supply Targets first, then the home warehouse, via real trade orders that participate in the mod's delivery/reservation bookkeeping; only wares that neither can take fall through to the existing `EmptyCargoRoutine` (`failedOrderHandling`). Afterwards a `ReturnToWarehouse` order is queued so follow-up mining starts from the correct anchor.

## New settings

- Fleet parameter **Mine When Idle** (`miningFallback`, bool, **default off** — existing fleets are unaffected; `<patch sinceversion="44">` heals running order instances in existing saves).
- Fleet parameter **Mining: Max Gate Distance** (`miningMaxGateDistance`, 0–10, default 3): how far from the home sector the trip may search; 0 = home sector only.
- Global setting **Mining fallback idle time** (slider in the existing Extension Options menu, default 60s), seeded via `Config` cue `<patch sinceversion="8">`.

## Behavior change for mining-capable ships with leftover cargo

Previously, any leftover cargo at scheduler entry went straight to `EmptyCargoRoutine` (refund/teleport/destroy/return/drop). For ships with solid/liquid capacity this PR routes leftover cargo through the supply-target → home-warehouse delivery path first, which is strictly gentler; `EmptyCargoRoutine` remains the final fallback. **Container-only ships are completely unaffected** — they keep the original path.

## Files changed

| File | Change |
| --- | --- |
| `aiscripts/order.warehousefleet.mining.xml` | **new** — one-shot mining order (`WarehouseFleetMine`) |
| `aiscripts/order.warehousefleet.xml` | version 43→44, two new params with `sinceversion="44"` patches |
| `md/warehousefleets.xml` | Config cue v7→8 (+ idle-time global); main cue v15→16 (+ `$miningOps`/`$idleSince`); scheduler hook; `TryMiningFallback`, `PickMiningWare`, `DeliverMinedCargoOrFallback` libraries; GarbageCollector cleanup |
| `md/warehousefleets_menu.xml` | one slider row (global settings section) |
| `libraries/icons.xml` | icon for the new order (uses the current `assets\textures\ui\order\` path — the pre-9.0 `assets\fx\gui\textures\` path used by the two existing entries no longer resolves in 9.00, left untouched here to keep this PR focused) |
| `readme.md` | documents the new fleet parameters, global setting, and a short feature section |

## Save compatibility

- No existing blocking actions in any aiscript are touched (the two new params are metadata only), so suspended order states import cleanly.
- New order params are patched into running `WarehouseFleet` order instances via `sinceversion="44"`.
- The main cue version bump (15→16) triggers the mod's existing reset path, which initializes the new bookkeeping tables on existing saves.
- Everything is opt-in; with "Mine When Idle" left off, the only behavior difference is the leftover-cargo routing described above.

## Notes for review

- One deliberate design point: `WarehouseFleetMine` requires the ship to be idle in the strict sense (`$ship.orders.count == 0`) before the idle clock even ticks, because `ScheduleFollowUpTripWhenDocking` pre-plans trips while the previous trade is still executing.
- The new aiscript declares a `debugchance` param (default 0) even though its own file logging uses the mod's usual always-on `debug_to_file` style: the vanilla interrupt handlers it references (e.g. `interrupt.inspected`) read `$debugchance` from the interrupted script's scope and raise "Property lookup failed" if it is undefined. (The same applies to the existing `WarehouseFleet` order — that fix is already committed in another PR.)
